### PR TITLE
Add audio tag in Exclude list #deleteExclusionTags

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -818,7 +818,7 @@ const util = {
      * @private
      */
     _deleteExclusionTags: (function () {
-        const exclusionTags = 'br|p|div|pre|blockquote|h[1-6]|ol|ul|dl|li|hr|figure|figcaption|img|iframe|video|table|thead|tbody|tr|th|td|a|b|strong|var|i|em|u|ins|s|span|strike|del|sub|sup'.split('|');
+        const exclusionTags = 'br|p|div|pre|blockquote|h[1-6]|ol|ul|dl|li|hr|figure|figcaption|img|iframe|audio|video|table|thead|tbody|tr|th|td|a|b|strong|var|i|em|u|ins|s|span|strike|del|sub|sup'.split('|');
         let regStr = '<\/?(';
 
         for (let i = 0, len = exclusionTags.length; i < len; i++) {


### PR DESCRIPTION
[My pluxml plugin](http://sudwebdesign.free.fr/index.php?article34),
make an insert with [pluxml](https://www.pluxml.org/) medias manager
to publish images, videos & audios elements in SunEditor panels

At first time, all audio publisheds in panel play well :)
After save the doc, the  audio tags is in published html source :)
But with SunEditor 2.15.3 after load & wysiwyg ready,
all audio tags is removed in editors panel :/
Images & videos are ok :)

This list of delete Exclusion Tags solve this problem.

Thanks @magoyo for this pathway & @JiHong88 to accept ;)