### PR TITLE
Switch spelling from hilite -> highlight

### DIFF
--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -36,7 +36,7 @@
             superscript: 'Superscript',
             removeFormat: 'Remove Format',
             fontColor: 'Font Color',
-            hiliteColor: 'Hilite Color',
+            hiliteColor: 'Highlight Color',
             indent: 'Indent',
             outdent: 'Outdent',
             align: 'Align',


### PR DESCRIPTION
The spelling hilite is [informal](https://en.wiktionary.org/wiki/hilite) and not widely used among all english speakers. So it would be better to use the proper english spelling highlight in the user interface.