### PR TITLE
Fix usage when the Editor is rendered in a popup window

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -24,8 +24,8 @@ import notice from '../plugins/modules/notice';
  * @returns {Object} UserFunction Object
  */
 export default function (context, pluginCallButtons, plugins, lang, _options) {
-    const _d = document;
-    const _w = window;
+    const _d = context.element.originElement.ownerDocument || document;
+    const _w = _d.defaultView || window;
     const util = _util;
 
     /**

--- a/test/dev/suneditor_build_test.html
+++ b/test/dev/suneditor_build_test.html
@@ -188,8 +188,11 @@
                 </textarea>
                 <button type="button" class="btn btn-md btn-success" onclick="sun_destroy3()">Destroy</button>
                 <button type="button" class="btn btn-md btn-success" onclick="sun_create3()">Create</button>
+                <br><br><br>
+                <button type="button" class="btn btn-md btn-success" onclick="sun_create4()">Create in window</button>
                 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
                 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+                
             </div>
     </div>
 </body>

--- a/test/dev/suneditor_build_test.js
+++ b/test/dev/suneditor_build_test.js
@@ -405,3 +405,36 @@ window.sun_create3 = function () {
     s3 = suneditor.create(document.getElementsByName('editor3')[0], {
     });
 }
+
+let s4;
+
+window.sun_create4 = function() {
+    const win = window.open();
+    document.querySelectorAll('link').forEach(function (linkNode) {
+        win.document.write(linkNode.outerHTML);
+    })
+    win.document.write('<textarea name="editor4" id="editor4" style="width: 1080px; height: 200px;"></textarea>');
+    s4 = suneditor.create(win.document.querySelector('#editor4'), {
+        plugins: plugins,
+        buttonList: [
+            ['undo', 'redo','removeFormat',
+            'font', 'fontSize', 'formatBlock',
+            'bold', 'underline', 'italic', 'strike', 'subscript', 'superscript',
+            'fontColor', 'hiliteColor',
+            'outdent', 'indent',
+            'align', 'horizontalRule', 'list', 'table',
+            'link', 'image', 'video',
+            'fullScreen', 'showBlocks', 'codeView',
+            'preview', 'print', 'save']
+        ],
+        width: '100%',
+        stickyToolbar: 0,
+        imageWidth: 300,
+        mode: 'classic',
+        // toolbarWidth: 800,
+        height: 'auto',
+        // callBackSave: (contents) => {
+        //     console.log('callback')
+        // }
+    });
+}


### PR DESCRIPTION
Currently most editor operations fail when editor is rendered inside a popup window. This PR ensures that the correct window and document objects are used when the node is in  a different window.