### PR TITLE
fix onBlur type definition

### DIFF
--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -567,7 +567,7 @@ export default class SunEditor {
     onKeyUp: EventFn;
     onDrop: EventFn;
     onChange: (contents: string, core: Core) => void;
-    onBlur: EventFn;
+    onBlur: (e: FocusEvent, core: Core) => void;
     onPaste: (e: Event, cleanData: string, maxCharCount: number, core: Core) => void;
 
     /**


### PR DESCRIPTION
When I use `e.relatedTarget`
=> 
`Property 'relatedTarget' does not exist on type 'Event'.  TS2339`

In practice it is found to be a FocusEvent
```ts
onBlur: (e: FocusEvent, core: Core) => void

// lib.dom.d.ts
interface FocusEvent extends UIEvent {
    readonly relatedTarget: EventTarget | null;
}
```
