### PR TITLE
Fix tabbing

### DIFF
--- a/src/lib/constructor.js
+++ b/src/lib/constructor.js
@@ -600,6 +600,7 @@ export default {
         oButton.setAttribute('class', 'se-btn' + (buttonClass ? ' ' + buttonClass : '') + ' se-tooltip');
         oButton.setAttribute('data-command', dataCommand);
         oButton.setAttribute('data-display', dataDisplay);
+	oButton.setAttribute('tabindex', '-1');
         if (!innerHTML) innerHTML = '<span class="se-icon-text">!</span>';
         innerHTML += '<span class="se-tooltip-inner"><span class="se-tooltip-text">' + (title || dataCommand) + '</span></span>';
 


### PR DESCRIPTION
At the moment the new tabDisable option has usability problems:

* In classical mode a `tab` focuses on the toolbar of the next editor, while we want to go to the edit area of the next editor
* In inline mode, this problem doesn't exist (because the toolbars are not displayed) but `shift-tab` doesn't work (the focus may be in the hidden toolbar)

So here is a proposed solution by setting tabindex="-1" cf. https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex

Maybe it's not the right way to fix the problem, but it gives you a hint of what it could be.