### PR TITLE
Link protocol feature

### DIFF
--- a/src/lib/constructor.js
+++ b/src/lib/constructor.js
@@ -523,6 +523,7 @@ export default {
         options.templates = !options.templates ? null : options.templates;
         /** ETC */
         options.placeholder = typeof options.placeholder === 'string' ? options.placeholder : null;
+        options.linkProtocol = typeof options.linkProtocol === 'string' ? options.linkProtocol : null;
         /** Math (katex) */
         options.katex = options.katex ? options.katex.src ? options.katex : {src: options.katex} : null;
         /** Buttons */

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -16,6 +16,10 @@ export interface SunEditorOptions {
      */
     attributesWhitelist?: Record<string, string>;
     /**
+     * Protocol for the links (if link has been added without any protocol this one will be used).
+     */
+    linkProtocol?: string;
+    /**
      * Layout
      * ======
      */

--- a/src/plugins/dialog/link.js
+++ b/src/plugins/dialog/link.js
@@ -20,7 +20,8 @@ export default {
             focusElement: null,
             linkNewWindowCheck: null,
             linkAnchorText: null,
-            _linkAnchor: null
+            _linkAnchor: null,
+            linkProtocol: context.option.linkProtocol
         };
 
         /** link dialog */
@@ -131,7 +132,12 @@ export default {
             if (this.context.link.focusElement.value.trim().length === 0) return false;
 
             const contextLink = this.context.link;
-            const url = contextLink.focusElement.value;
+            let url = contextLink.focusElement.value;
+
+            if (contextLink.linkProtocol && url.indexOf('://') === -1 && url.indexOf('#') === -1) {
+                url = `${contextLink.linkProtocol}${url}`
+            }
+            
             const anchor = contextLink.linkAnchorText;
             const anchorText = anchor.value.length === 0 ? url : anchor.value;
 

--- a/src/plugins/dialog/link.js
+++ b/src/plugins/dialog/link.js
@@ -134,7 +134,7 @@ export default {
             const contextLink = this.context.link;
             let url = contextLink.focusElement.value;
 
-            if (contextLink.linkProtocol && url.indexOf('://') === -1 && url.indexOf('#') === -1) {
+            if (contextLink.linkProtocol && url.indexOf('://') === -1 && url.indexOf('#') !== 0) {
                 url = `${contextLink.linkProtocol}${url}`
             }
             

--- a/src/plugins/dialog/link.js
+++ b/src/plugins/dialog/link.js
@@ -135,7 +135,7 @@ export default {
             let url = contextLink.focusElement.value;
 
             if (contextLink.linkProtocol && url.indexOf('://') === -1 && url.indexOf('#') !== 0) {
-                url = `${contextLink.linkProtocol}${url}`
+                url = `${contextLink.linkProtocol}${url}`;
             }
             
             const anchor = contextLink.linkAnchorText;

--- a/test/dev/suneditor_build_test.js
+++ b/test/dev/suneditor_build_test.js
@@ -71,6 +71,7 @@ let ssss = suneditor.create(("sample1"), {
     toolbarContainer: document.getElementById('test_tool2'),
     tabDisable: true,
     fontSize: fs,
+    linkProtocol: 'https://',
     buttonList: [
         ['align'],
         ['-right', 'link'],
@@ -132,6 +133,7 @@ let s1 = suneditor.create('editor', {
     plugins: plugins,
     mode: 'balloon-always',
     katex: Katex,
+    linkProtocol: 'http://',
     fontSize: fs,
     resizingBar: true,
     height: '500px',


### PR DESCRIPTION
Hi @JiHong88, when I add a URL without a protocol it's using the current URL and after it, it's appending link value so in the end, URL can look like this https://mysite.com/google.com. I've added a new option so the protocol specified in the options will be automatically added if the user did not provide any. I was also thinking about another option - add https by default, let me know what do you think.