### PR TITLE
fix: Fixed an error that occurs by accessing scrollTop when the 'wysiwyg' instance is null.(util.js)

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1018,7 +1018,7 @@ const util = {
 
         return {
             left: offsetLeft + (iframe ? wysiwygFrame.parentElement.offsetLeft : 0),
-            top: (offsetTop - wysiwyg.scrollTop) + (iframe ? wysiwygFrame.parentElement.offsetTop : 0)
+            top: (offsetTop - wysiwyg ? wysiwyg.scrollTop : 0) + (iframe ? wysiwygFrame.parentElement.offsetTop : 0)
         };
     },
 


### PR DESCRIPTION
hi
I'm very happy with the libraries you provide and use.

While using the'suneditor-react' library I witnessed the following error.
![image](https://user-images.githubusercontent.com/15885679/103857752-703ca200-50fa-11eb-97db-0bea04d98b15.png)

Looking for the cause, I found that the value of'wysiwyg' obtained through getParentElement() of the getOffset() function is null.
In the comment of the getParentElement() function, the return value is {Element | null}.

So I modified the 'top' calculation code in the return object of the getOffset() function.
