### PR TITLE
Adapt module export for Typescript 2.6

### DIFF
--- a/src/plugins/index.d.ts
+++ b/src/plugins/index.d.ts
@@ -1,5 +1,3 @@
-import { Plugin } from './Plugin';
-
 // command
 import blockquote from './command/blockquote';
 
@@ -28,7 +26,7 @@ import math from './dialog/math';
 // file browser
 import imageGallery from './fileBrowser/imageGallery';
 
-declare const _plugins: Plugin[];
+declare const _plugins = { blockquote, align, font, fontSize, fontColor, hiliteColor, horizontalRule, list, table, formatBlock, lineHeight, template, paragraphStyle, textStyle, link, image, video, audio, math, imageGallery };
 
 export { blockquote, align, font, fontSize, fontColor, hiliteColor, horizontalRule, list, table, formatBlock, lineHeight, template, paragraphStyle, textStyle, link, image, video, audio, math, imageGallery };
 export default _plugins;

--- a/src/plugins/index.d.ts
+++ b/src/plugins/index.d.ts
@@ -26,5 +26,7 @@ import math from './dialog/math';
 // file browser
 import imageGallery from './fileBrowser/imageGallery';
 
+declare const _plugins: Plugin[];
+
 export { blockquote, align, font, fontSize, fontColor, hiliteColor, horizontalRule, list, table, formatBlock, lineHeight, template, paragraphStyle, textStyle, link, image, video, audio, math, imageGallery };
-export default { blockquote, align, font, fontSize, fontColor, hiliteColor, horizontalRule, list, table, formatBlock, lineHeight, template, paragraphStyle, textStyle, link, image, video, audio, math, imageGallery };
+export default _plugins;

--- a/src/plugins/index.d.ts
+++ b/src/plugins/index.d.ts
@@ -1,3 +1,5 @@
+import { Plugin } from './Plugin';
+
 // command
 import blockquote from './command/blockquote';
 

--- a/src/plugins/index.d.ts
+++ b/src/plugins/index.d.ts
@@ -26,7 +26,7 @@ import math from './dialog/math';
 // file browser
 import imageGallery from './fileBrowser/imageGallery';
 
-declare const _plugins = { blockquote, align, font, fontSize, fontColor, hiliteColor, horizontalRule, list, table, formatBlock, lineHeight, template, paragraphStyle, textStyle, link, image, video, audio, math, imageGallery };
+declare const _default: { blockquote, align, font, fontSize, fontColor, hiliteColor, horizontalRule, list, table, formatBlock, lineHeight, template, paragraphStyle, textStyle, link, image, video, audio, math, imageGallery };
 
 export { blockquote, align, font, fontSize, fontColor, hiliteColor, horizontalRule, list, table, formatBlock, lineHeight, template, paragraphStyle, textStyle, link, image, video, audio, math, imageGallery };
-export default _plugins;
+export default _default;


### PR DESCRIPTION
As per https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts, the current src/plugins/index.d.ts causes error (The expression of an export assignment must be an identifier or qualified name in an ambient context) when using Typescript 2.6 +.