### PR TITLE
Updated Typescript definitions for SunEditor

### DIFF
--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -708,15 +708,15 @@ export default class SunEditor {
 
     /**
      * @description An event when toggling between code view and wysiwyg view.
-     * @param isCodeView: Whether the current code view mode
-     * @paran core: Core object
+     * @param isCodeView Whether the current code view mode
+     * @param core Core object
      */
     toggleCodeView: (isCodeView: boolean, core: Core) => void;
 
     /**
      * @description An event when toggling full screen.
-     * @param isFullScreen: Whether the current full screen mode
-     * @param core: Core object
+     * @param isFullScreen Whether the current full screen mode
+     * @param core Core object
      */
     toggleFullScreen: (isFullScreen: boolean, core: Core) => void;
 

--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -707,6 +707,20 @@ export default class SunEditor {
     audioUploadHandler: (xmlHttp: XMLHttpRequest, info: audioInputInformation, core: Core) => void;
 
     /**
+     * @description An event when toggling between code view and wysiwyg view.
+     * @param isCodeView: Whether the current code view mode
+     * @paran core: Core object
+     */
+    toggleCodeView: (isCodeView: boolean, core: Core) => void;
+
+    /**
+     * @description An event when toggling full screen.
+     * @param isFullScreen: Whether the current full screen mode
+     * @param core: Core object
+     */
+    toggleFullScreen: (isFullScreen: boolean, core: Core) => void;
+
+    /**
      * @description Called before the image is uploaded
      * If true is returned, the internal upload process runs normally.
      * If false is returned, no image upload is performed.


### PR DESCRIPTION
I added the the toggleFullScreen, as well as the toggleCodeView event to the Typescript definition of the SunEditor class. The documentation is directly copied from the README.md.