### PR TITLE
ImageGallery with Request-Headers Error

### DIFF
--- a/src/plugins/modules/fileBrowser.js
+++ b/src/plugins/modules/fileBrowser.js
@@ -213,12 +213,12 @@
 
             const xmlHttp = fileBrowserPlugin._xmlHttp = this.util.getXMLHttpRequest();
             xmlHttp.onreadystatechange = fileBrowserPlugin._callBackGet.bind(this, xmlHttp);
+            xmlHttp.open('get', url, true);
             if(browserHeader !== null && typeof browserHeader === 'object' && this._w.Object.keys(browserHeader).length > 0){
                 for(let key in browserHeader){
                     xmlHttp.setRequestHeader(key, browserHeader[key]);
                 }
             }
-            xmlHttp.open('get', url, true);
             xmlHttp.send(null);
 
             this.plugins.fileBrowser.showBrowserLoading();


### PR DESCRIPTION
When using the ImageGallery with Request-Headers set following error occurs:
`Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.`

Because the XMLHttpRequest has to be opened before setting the Request-Headers.
