### PR TITLE
fix onCopy and OnCut callback return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1109,6 +1109,10 @@ editor.onPaste = function (e, cleanData, maxCharCount, core) { console.log('onPa
  * core: Core object
  */
 editor.onCopy = function (e, clipboardData, core) { console.log('onCopy', e) }
+
+// Cut event.
+// Called before the editor's default event action.
+// If it returns false, it stops without executing the rest of the action.
 /**
  * cut event
  * e: Event object

--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,10 @@ editor.onload = function (core, reload) {
  * core: Core object
  */
 editor.onPaste = function (e, cleanData, maxCharCount, core) { console.log('onPaste', e) }
+
+// Copy event.
+// Called before the editor's default event action.
+// If it returns false, it stops without executing the rest of the action.
 /**
  * copy event
  * e: Event object

--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -646,7 +646,7 @@ export default class SunEditor {
     onDrop: (e: Event, cleanData: string, maxCharCount: number, core: Core) => boolean | string;
     onPaste: (e: Event, cleanData: string, maxCharCount: number, core: Core) => boolean | string;
     onCopy: (e: Event, clipboardData: any, core: Core) => boolean;
-    onCut: (e: Event, clipboardData: any, core: Core) => void;
+    onCut: (e: Event, clipboardData: any, core: Core) => boolean;
 
     /**
      * @description Called just before the inline toolbar is positioned and displayed on the screen.

--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -645,7 +645,7 @@ export default class SunEditor {
     onBlur: (e: FocusEvent, core: Core) => void;
     onDrop: (e: Event, cleanData: string, maxCharCount: number, core: Core) => boolean | string;
     onPaste: (e: Event, cleanData: string, maxCharCount: number, core: Core) => boolean | string;
-    onCopy: (e: Event, clipboardData: any, core: Core) => void;
+    onCopy: (e: Event, clipboardData: any, core: Core) => boolean;
     onCut: (e: Event, clipboardData: any, core: Core) => void;
 
     /**


### PR DESCRIPTION
Return types of this functions needs to be boolean as the default behavior would be accidentally disabled if you override it with a function that returns void.