### PR TITLE
#847 remove video controls attr by default

### DIFF
--- a/src/plugins/dialog/video.js
+++ b/src/plugins/dialog/video.js
@@ -219,8 +219,6 @@ export default {
     },
 
     _setTagAttrs: function (element) {
-        element.setAttribute('controls', true);
-
         const attrs = this.options.videoTagAttrs;
         if (!attrs) return;
 


### PR DESCRIPTION
# Context:
* As discussed with @SystemChanger in issue #847 , we decide to make this PR to remove `controls=true` default attribute added by video editor.
* The problem was when using HTML code editor and remove  `controls=true`  attribute, it added it back when switch to text editor.

# Change:
* removed `element.setAttribute('controls', true)` in `video.js`  function `_setTagAttrs` like that `controls=true` will stop auto append

# Example
* Before:
![image](https://user-images.githubusercontent.com/2559543/128960351-d48bef52-b04a-4c4a-b561-eb1224da435a.png)

* After
![image](https://user-images.githubusercontent.com/2559543/128960386-2743e257-d1e8-4ba2-a00e-d5d7b4a6d411.png)
