### PR TITLE
link target update

### DIFF
--- a/src/plugins/dialog/link.js
+++ b/src/plugins/dialog/link.js
@@ -174,7 +174,8 @@ export default {
         this.editLink = this.context.link._linkAnchor = this.context.anchor.caller.link.linkAnchor = selectionATag;
         const linkBtn = this.context.link.linkController;
         const link = linkBtn.querySelector('a');
-
+        
+        link.target = this.editLink.getAttribute('target');
         link.href = selectionATag.href;
         link.title = selectionATag.textContent;
         link.textContent = selectionATag.textContent;


### PR DESCRIPTION
Whether the option for "open link in new window" is selected or not it was giving the same value to inside link i.e. 'target="_blank"'.