### PR TITLE
Added `linkNoPrefix` option to be able to prevent the prefixing of the host to a link value

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,7 @@ linkRelDefault  : Defines default "rel" attributes of anchor tag.   default: {} 
                     linkRelDefault: {
                         check_new_window: 'only:noreferrer noopener'
                     }
+linkNoPrefix   : It prevents the automatic prefixing of the host URL to the value of the link when `true`.
 
 // Key actions----------------------------------------------------------------------------------------------------
 tabDisable      : If true, disables the interaction of the editor and tab key.  default: false {Boolean}

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -467,6 +467,11 @@ export interface SunEditorOptions {
      * Defines default "rel" attribute list of anchor tag.
      */
     linkRelDefault?: {default?: string; check_new_window?: string; check_bookmark?: string;};
+
+    /**
+     * It prevents the automatic prefixing of the host URL to the value of the link when `true`.
+     */
+    linkNoPrefix?: boolean;
     /**
      * Key actions
      * =====

--- a/src/plugins/modules/_anchor.js
+++ b/src/plugins/modules/_anchor.js
@@ -293,9 +293,10 @@ export default {
     setLinkPreview: function (context, value) {
         const preview = context.preview;
         const protocol = this.options.linkProtocol;
+        const noPrefix = this.options.linkNoPrefix;
         const reservedProtocol  = /^(mailto\:|tel\:|sms\:|https*\:\/\/|#)/.test(value);
         const sameProtocol = !protocol ? false : this._w.RegExp('^' + value.substr(0, protocol.length)).test(protocol);
-        context.linkValue = preview.textContent = !value ? '' : (protocol && !reservedProtocol && !sameProtocol) ? protocol + value : reservedProtocol ? value : /^www\./.test(value) ? 'http://' + value : this.context.anchor.host + (/^\//.test(value) ? '' : '/') + value;
+        context.linkValue = preview.textContent = !value ? '' : noPrefix ? value : (protocol && !reservedProtocol && !sameProtocol) ? protocol + value : reservedProtocol ? value : /^www\./.test(value) ? 'http://' + value : this.context.anchor.host + (/^\//.test(value) ? '' : '/') + value;
 
         if (value.indexOf('#') === 0) {
             context.bookmark.style.display = 'block';


### PR DESCRIPTION
In a project that I'm working on, I need the ability to enter text in a link field, but the host prefix should not be added in that situation (the value does not contain any specific protocols). This optional option allows for that.