### PR TITLE
Issue solved where the Edit/Update button is clicked on a link and prefix was added by the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ linkRelDefault  : Defines default "rel" attributes of anchor tag.   default: {} 
                     linkRelDefault: {
                         check_new_window: 'only:noreferrer noopener'
                     }
-linkNoPrefix   : It prevents the automatic prefixing of the host URL to the value of the link when `true`.
+linkNoPrefix   : If true, disables the automatic prefixing of the host URL to the value of the link. default: false {Boolean}
 
 // Key actions----------------------------------------------------------------------------------------------------
 tabDisable      : If true, disables the interaction of the editor and tab key.  default: false {Boolean}

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -467,9 +467,8 @@ export interface SunEditorOptions {
      * Defines default "rel" attribute list of anchor tag.
      */
     linkRelDefault?: {default?: string; check_new_window?: string; check_bookmark?: string;};
-
     /**
-     * It prevents the automatic prefixing of the host URL to the value of the link when `true`.
+     * If true, disables the automatic prefixing of the host URL to the value of the link. default: false {Boolean}
      */
     linkNoPrefix?: boolean;
     /**

--- a/src/plugins/modules/_anchor.js
+++ b/src/plugins/modules/_anchor.js
@@ -124,7 +124,7 @@ export default {
             contextAnchor.anchorText.value = this.getSelection().toString();
         } else if (contextAnchor.linkAnchor) {
             this.context.dialog.updateModal = true;
-            const href = contextAnchor.linkAnchor.href;
+            const href = this.options.linkNoPrefix ? contextAnchor.linkAnchor.href.replace(contextAnchor.linkAnchor.origin + '/', '') : contextAnchor.linkAnchor.href;
             contextAnchor.linkValue = contextAnchor.preview.textContent = contextAnchor.urlInput.value = /\#.+$/.test(href) ? href.substr(href.lastIndexOf('#')) : href;
             contextAnchor.anchorText.value = contextAnchor.linkAnchor.textContent.trim() || contextAnchor.linkAnchor.getAttribute('alt');
             contextAnchor.newWindowCheck.checked = (/_blank/i.test(contextAnchor.linkAnchor.target) ? true : false);


### PR DESCRIPTION
Using the `linkNoPrefix` option, the origin of the link was still filled into the URL text field after clicking on the update/edit button. Added a `replace` for the `origin` + trailing `/` to prevent this from happening. It looks like the browser does this automatically, or have I missed some code that adds this?

Also updated the comments for the `linkNoPrefix` option to reflect the same structure that other comments have.