### PR TITLE
fix: link.submit

### DIFF
--- a/src/plugins/dialog/link.js
+++ b/src/plugins/dialog/link.js
@@ -118,6 +118,7 @@ export default {
 
         try {
             const oA = this.plugins.anchor.createAnchor.call(this, this.context.anchor.caller.link, false);
+            if (oA === null) return;
     
             if (!this.context.dialog.updateModal) {
                 const selectedFormats = this.getSelectedElements();


### PR DESCRIPTION
When I inserted a link with an empty URL, then I got an error below and the selected text was deleted.

```
Exception has occurred: TypeError: Failed to execute 'insertBefore' on 'Node': parameter 1 is not of type 'Node'.
  at Object.insertNode ([webpack-internal:///./src/lib/core.js:1892:20]())
    at Object.submit ([webpack-internal:///./src/plugins/dialog/link.js:97:21]())
```

This pull request fix this error by return early if `oA === null`.