### PR TITLE
Add historyStackDelayTime option to typings

### DIFF
--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -25,6 +25,10 @@ export interface SunEditorOptions {
      */
     value?: string;
     /**
+     * When recording the history stack, this is the delay time (miliseconds) since the last input. default: 400
+     */
+    historyStackDelayTime?: number;
+    /**
      * Whitelist
      * ======
      */


### PR DESCRIPTION
Official typings miss `historyStackDelayTime` option.