### PR TITLE
Fix : Toolbar sticky size, fullscreen to normal

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -7583,7 +7583,7 @@ export default function (context, pluginCallButtons, plugins, lang, options, _re
             }
 
             element.toolbar.style.top = (options.stickyToolbar + inlineOffset) + 'px';
-            element.toolbar.style.width = core._isInline ? core._inlineToolbarAttr.width : element.toolbar.offsetWidth + 'px';
+            element.toolbar.style.width = core._isInline ? core._inlineToolbarAttr.width : element.editorArea.offsetWidth + 'px';
             util.addClass(element.toolbar, 'se-toolbar-sticky');
             core._sticky = true;
         },


### PR DESCRIPTION
 _offStickyToolbar: 
Size of toolbar when is sticky (from textarea), go fullscreen mode (ok) and click to return to normal mode (no fullscreen mode), the Toolbar is to large.

And to solve without this, when toolbar is sticky go on top page to unsticky toolbar ==  good width (same of textarea)