### PR TITLE
Fixed an error when IE11+ complained when deleting empty paragraph with Backspace key

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -6986,7 +6986,7 @@ export default function (context, pluginCallButtons, plugins, lang, options, _re
                         const prev = formatEl.previousSibling;
                         // select file component
                         const ignoreZWS = (commonCon.nodeType === 3 || util.isBreak(commonCon)) && !commonCon.previousSibling && range.startOffset === 0;
-                        if (!sel.previousSibling && (util.isComponent(commonCon.previousSibling) || (ignoreZWS && util.isComponent(prev)))) {
+                        if (sel && !sel.previousSibling && ( (commonCon && util.isComponent(commonCon.previousSibling)) || (ignoreZWS && util.isComponent(prev)))) {
                             const fileComponentInfo = core.getFileComponent(prev);
                             if (fileComponentInfo) {
                                 e.preventDefault();
@@ -7001,7 +7001,7 @@ export default function (context, pluginCallButtons, plugins, lang, options, _re
                             break;
                         }
                         // delete nonEditable
-                        if (util.isNonEditable(sel.previousSibling)) {
+                        if (sel && util.isNonEditable(sel.previousSibling)) {
                             e.preventDefault();
                             e.stopPropagation();
                             util.removeItem(sel.previousSibling);


### PR DESCRIPTION
SunEditor throws an error of "Unable to get property 'previousSibling' of undefined or null" in Internet Explorer 11+ when trying to delete empty paragraph between 2 other paragraphs when using Backspace key. Implemented better conditional checks to avoid this random error.

Bug explained in Issue #1175 in detail.