### PR TITLE
css restructuring with themes

### DIFF
--- a/src/assets/suneditor.css
+++ b/src/assets/suneditor.css
@@ -1,18 +1,189 @@
-/* used color #000 , #fff , #CCC, #f5f5f5, #f9f9f9 */
-/* font color #333, background color: #fff */
-/* grey color #e1e1e1, #ececec, #d1d1d1 , #c1c1c1 , #b1b1b1 */
-/* blue color #eaf3ff, #dbeaff(shadow: #b7ccf2, #e6f2ff), #c4ddff, #d0e3ff , #80bdff , #3f9dff , #4592ff, #407dd1, #3288ff, #1275ff */
-/* red color #b94a48 , #f2dede , #eed3d7, #d9534f */
+/* All classes used must begin with "__se__". */
+
+:root,
+[data-se-theme="light"] {
+	--se-font-sans-serif: "Arial", "Comic Sans MS", "Courier New", "Impact", "Georgia", "tahoma", "Trebuchet MS", "Verdana";
+	--se-font-monospace: "monospace";
+
+	--se--a-color: #4592ff;
+	--se--border: #999;
+	--se--border-light: #e1e1e1;
+	--se--component-bg: #fbfbfb;
+	--se--disabled: #bdbdbd;
+	--se--hover: #d8d7d7;
+	--se--outline: #989898;
+	--se--shadow: #bfbebe;
+
+	--se--active-bg: #80bdff;
+	--se--active-border: #3f9dff;
+	--se--active-color: #f62109;
+	--se--active-hover-bg: #4592ff;
+	--se--active-hover-border: #aaa9a9;
+	--se--active-hover-color: #000000;
+
+	--se--blockquote-border: #d1d1d1;
+	--se--blockquote-color: #999;
+
+	--se--editable-a-color: #004cff;
+	--se--editable-a-hover: #0093ff;
+	--se--editable-a-on: #e8f7ff;
+	--se--editable-bg: #fff;
+	--se--editable-color: #202020;
+	--se--editable-hr: #202020;
+	--se--editable-pre-bg: #f9f9f9;
+	--se--editable-pre-color: #666;
+
+	--se--editable-t-code-bg: rgba(35, 29, 27, 0.05);
+	--se--editable-t-code-color: #666;
+	--se--editable-t-code-text-shadow1: #999;
+	--se--editable-t-code-text-shadow2: #888;
+	--se--editable-t-code-text-shadow3: #777;
+	--se--editable-t-code-text-shadow4: #666;
+	--se--editable-t-code-text-shadow5: #555;
+	--se--editable-t-code-text-shadow6: #fff;
+
+	--se--editable-table-border: #cccccc;
+	--se--editable-table-th-bg: #f3f3f3;
+	--se--editable-table-th-border: #e1e1e1;
+	--se--editable-table-thead: #646464;
+	--se--editable-table-tr-border: #efefef;
+
+	--se--editor-bg: #fff;
+	--se--editor-color: #202020;
+	--se--error-color: #d9534f;
+	--se--error-shadow: #eed3d7;
+
+	--se--figcaption-bg: #f9f9f9;
+	--se--figcaption-focus-border: #80bdff;
+
+	--se--line-breaker-border-top: #3288ff;
+	--se--line-breaker-btn-bg: #4592ff;
+	--se--line-breaker-btn-border: #3288ff;
+	--se--line-breaker-btn-color: #fff;
+	--se--line-breaker-btn-hover-bg: #4592ff;
+	--se--line-breaker-btn-hover-border: #3288ff;
+	--se--line-breaker-btn-hover-color: #fff;
+
+	--se--list-default-value-bg: #f3f3f3;
+
+	--se--notice-color: #b94a48;
+
+	--se--p-neon-bg: #000;
+	--se--p-neon-border: #fff;
+	--se--p-neon-color: #fff;
+	--se--p-neon-flicker-box: #08f;
+	--se--p-neon-flicker-text-shadow: #fff;
+	--se--p-neon-flicker-txt: #f40;
+
+	--se--resize-display-bg: #fff;
+	--se--resize-display-color: #fff;
+	--se--resize-display: #333;
+	--se--resize-dot-span-bg: #4592ff;
+	--se--resize-dot-span-border: #69a7fe;
+	--se--resize-dot: #80bdff;
+
+	--se--show-block-border: var(--se--active-border);
+	--se--show-block-ol: #d539ff;
+	--se--show-block-pre: #27c022;
+
+	--se--status-bar-bg: #cac6c6;
+	--se--status-bar-color: #999;
+
+	--se--tooltip-bg: #333;
+	--se--tooltip-border: #595959;
+	--se--tooltip-color: #fff;
+
+
+
+
+	/* MARIN - REVIEW WHEN HAVE JS WORKING */
+
+
+	--se--btn-enabled-on-active-bg: #146df3;
+	--se--btn-enabled-on-active-border: #d0e3ff;
+	--se--btn-enabled-on-active-color: #3288ff;
+	--se--btn-enabled-on-active-outline: #3288ff;
+	--se--btn-enabled-on-active-shadow: #d0e3ff;
+	--se--btn-enabled-on-bg: #eaf3ff;
+	--se--btn-enabled-on-color: #4592ff;
+	--se--btn-enabled-on-hover-bg: #d0e3ff;
+	--se--btn-enabled-on-hover-color: #407dd1;
+	--se--btn-primary-active-bg: #f3530e;
+	--se--btn-primary-active-border: #eaf3ff;
+	--se--btn-primary-active-shadow: #eaf3ff;
+	--se--btn-primary-bg: #eaf3ff;
+	--se--btn-primary-border: #1275ff;
+	--se--file-browser-back-bg: #222;
+	--se--file-browser-color: #222;
+	--se--file-browser-content-bg: #fff;
+	--se--file-browser-content-border: rgba(0, 0, 0, 0.2);
+	--se--file-browser-file-name-image-color: #fff;
+	--se--file-browser-header-border-bottom: #e5e5e5;
+	--se--file-browser-header-close-text-shadow: #fff;
+	--se--file-browser-list-hover-shadow: #3288ff;
+	--se--file-browser-name-back-bg: #333;
+	--se--file-browser-tags-a-active: #d1d1d1;
+	--se--file-browser-tags-a-bg: #f5f5f5;
+	--se--file-browser-tags-a-color: #333;
+	--se--file-browser-tags-a-hover-bg: #e1e1e1;
+	--se--file-browser-tags-a-on-active-bg: #d0e3ff;
+	--se--file-browser-tags-a-on-bg: #ebf3fe;
+	--se--file-browser-tags-a-on-color: #4592ff;
+	--se--file-browser-tags-a-on-hover: #d8e8fe;
+	--se--form-group-btn-border: #ccc;
+	--se--form-group-color-input-border-bottom: #b1b1b1;
+	--se--form-group-color-input-focus-border-bottom: #b1b1b1;
+	--se--form-group-input-border: #ccc;
+	--se--form-group-input-color: #555;
+	--se--line-breaker-component-bg: #4592ff;
+	--se--line-breaker-component-border: #3288ff;
+	--se--line-breaker-component-color: #fff;
+	--se--modal-anchor-rel-btn-color: #3f9dff;
+	--se--modal-back-bg: #222;
+	--se--modal-btn-check-color: #999;
+	--se--modal-color: #111;
+	--se--modal-content-bg: #fff;
+	--se--modal-content-border: rgba(0, 0, 0, 0.2);
+	--se--modal-content-shadow: rgba(0, 0, 0, 0.5);
+	--se--modal-files-edge-button-border: #ccc;
+	--se--modal-footer-border-top: #e5e5e5;
+	--se--modal-form-a-color: #004cff;
+	--se--modal-header-border: #e5e5e5;
+	--se--modal-header-close-text-shadow: #fff;
+	--se--modal-input-disabled-bg: #f3f3f3;
+	--se--modal-link-preview-color: #666;
+	--se--modal-math-exp-border: var(--se--active-border);
+	--se--modal-math-preview-span-shadow: #d0e3ff;
+	--se--modal-tabs-border-bottom: #e5e5e5;
+	--se--modal-tabs-button-active-bg: #fff;
+	--se--modal-tabs-button-bg: #e5e5e5;
+	--se--modal-tabs-button-border-right: #e5e5e5;
+	--se--modal-tabs-button-hover-bg: #fff;
+	--se--select-item-active-bg: #094ca9;
+	--se--select-item-active-border: #dbeaff;
+	--se--select-item-active-outline: #3288ff;
+	--se--select-item-active-shadow1: #b7ccf2;
+	--se--select-item-active-shadow2: #e6f2ff;
+	--se--select-item-hover-border: #d0e3ff;
+	--se--select-item-hover-outline: #3288ff;
+	--se--select-item-hover-shadow: #d0e3ff;
+	--se--select-item-on-color: #4592ff;
+	--se--select-menu-bg: #fff;
+	--se--wrapper-code-color: #fff;
+	--se--wrapper-code: #191919;
+	--se--wrapper-placeholder-color: #b1b1b1;
+
+}
 
 /** --- suneditor main */
 .sun-editor {
 	width: auto;
 	height: auto;
 	box-sizing: border-box;
-	font-family: Helvetica Neue;
-	border: 1px solid #dadada;
-	background-color: #fff;
-	color: #000;
+	font-family: var(--se-font-sans-serif);
+	border: 1px solid var(--se--border);
+	background-color: var(--se--editor-bg);
+	color: var(--se--editor-color);
 }
 
 .sun-editor * {
@@ -127,7 +298,7 @@
 
 /** button */
 .sun-editor button {
-	color: #000;
+	color: var(--se--editor-color);
 }
 
 /** --- se buttons ---------------------------------------------------------- */
@@ -151,87 +322,86 @@
 
 .sun-editor .se-btn:enabled:hover,
 .sun-editor .se-btn:enabled:focus {
-	background-color: #e1e1e1;
-	border-color: #d1d1d1 !important;
+	background-color: var(--se--active-hover-bg);
+	border-color: var(--se--active-hover-border) !important;
 }
 
 .sun-editor .se-btn:enabled:active,
 .sun-editor .se-btn:enabled.__se__active {
-	background-color: #ececec;
-	border-color: #ececec !important;
-	outline: 1px solid #b1b1b1 !important;
-	-webkit-box-shadow: 0 0 0 0.3rem #ececec;
-	box-shadow: 0 0 0 0.3rem #ececec;
+	background-color: var(--se--active-bg);
+	border-color: var(--se--active-border) !important;
+	outline: 1px solid var(--se--outline) !important;
+	-webkit-box-shadow: 0 0 0 0.3rem var(--se--shadow);
+	box-shadow: 0 0 0 0.3rem var(--se--shadow);
 	transition: box-shadow 0.1s ease-in-out;
 }
 
 /* se-btn.on */
 .sun-editor .se-btn:enabled.on {
-	background-color: #eaf3ff;
-	color: #4592ff;
+	background-color: var(--se--btn-enabled-on-bg);
+	color: var(--se--btn-enabled-on-color);
 }
 
 .sun-editor .se-btn:enabled.on:hover,
 .sun-editor .se-btn:enabled.on:focus {
-	background-color: #d0e3ff;
-	color: #407dd1;
+	background-color: var(--se--btn-enabled-on-hover-bg);
+	color: var(--se--btn-enabled-on-hover-color);
 }
 
 .sun-editor .se-btn:enabled.on:active,
 .sun-editor .se-btn:enabled.on.__se__active {
-	background-color: #d0e3ff;
-	color: #3288ff;
-	border-color: #d0e3ff !important;
-	outline: 1px solid #3288ff !important;
-	color: 1px solid #3288ff;
-	-webkit-box-shadow: 0 0 0 0.3rem #d0e3ff;
-	box-shadow: 0 0 0 0.3rem #d0e3ff;
+	background-color: var(--se--btn-enabled-on-active-bg);
+	color: var(--se--btn-enabled-on-active-color);
+	border-color: var(--se--btn-enabled-on-active-border) !important;
+	outline: 1px solid var(--se--btn-enabled-on-active-outline) !important;
+	-webkit-box-shadow: 0 0 0 0.3rem var(--se--btn-enabled-on-active-shadow);
+	box-shadow: 0 0 0 0.3rem var(--se--btn-enabled-on-active-shadow);
 	transition: box-shadow 0.1s ease-in-out;
 }
 
 /* se-btn.active */
 .sun-editor .se-btn:enabled.active {
-	background-color: #dbeaff;
-	color: #4592ff;
+	background-color: var(--se--active-bg);
+	color: var(--se--active-color);
 }
 
 .sun-editor .se-btn:enabled.active:hover,
 .sun-editor .se-btn:enabled.active:focus {
-	background-color: #c4ddff;
-	color: #1275ff;
+	background-color: var(--se--active-bg);
+	color: var(--se--active-hover-color);
 }
 
 .sun-editor .se-btn:enabled.active:active,
 .sun-editor .se-btn:enabled.active.__se__active {
-	background-color: #c4ddff;
-	color: #1275ff;
-	border-color: #1275ff !important;
-	outline: 1px solid #1275ff !important;
-	-webkit-box-shadow: 0 0 0 0.3rem #c4ddff;
-	box-shadow: 0 0 0 0.3rem #c4ddff;
+	background-color: var(--se--active-bg);
+	color: var(--se--active-color);
+	border-color: var(--se--active-border) !important;
+	outline: 1px solid var(--se--outline) !important;
+	-webkit-box-shadow: 0 0 0 0.3rem var(--se--shadow);
+	box-shadow: 0 0 0 0.3rem var(--se--shadow);
 	transition: box-shadow 0.1s ease-in-out;
 }
 
 /** --- primary button */
 .sun-editor .se-btn-primary {
-	background-color: #eaf3ff;
-	border: 1px solid #1275ff;
+	background-color: var(--se--btn-primary-bg);
+	border: 1px solid var(--se--btn-primary-border);
 	border-radius: 2px;
 	outline: 0 none;
 }
 
 .sun-editor .se-btn-primary:hover,
 .sun-editor .se-btn-primary:focus {
-	background-color: #c4ddff;
+	background-color: var(--se--shadow);
 }
 
 .sun-editor .se-btn-primary:active,
 .sun-editor .se-btn-primary.__se__active {
-	background-color: #eaf3ff;
-	border-color: #eaf3ff !important;
-	outline: 1px solid #1275ff !important;
-	-webkit-box-shadow: 0 0 0 0.3rem #eaf3ff;
-	box-shadow: 0 0 0 0.3rem #eaf3ff;
+	background-color: var(--se--btn-primary-active-bg);
+	border-color: var(--se--btn-primary-active-border) !important;
+	outline: 1px solid var(--se--outline) !important;
+	-webkit-box-shadow: 0 0 0 0.3rem var(--se--btn-primary-active-shadow);
+	box-shadow: 0 0 0 0.3rem var(--se--btn-primary-active-shadow);
 	transition: box-shadow 0.1s ease-in-out;
 }
 
@@ -239,18 +409,18 @@
 .sun-editor input,
 .sun-editor select,
 .sun-editor textarea {
-	color: #000;
-	border: 1px solid #ccc;
+	color: var(--se--editor-color);
+	border: 1px solid var(--se--border);
 	border-radius: 2px;
 }
 
 .sun-editor input:focus,
 .sun-editor select:focus,
 .sun-editor textarea:focus {
-	border: 1px solid #80bdff;
+	border: 1px solid var(--se--border);
 	outline: 0;
-	-webkit-box-shadow: 0 0 0 0.2rem #d0e3ff;
-	box-shadow: 0 0 0 0.2rem #d0e3ff;
+	-webkit-box-shadow: 0 0 0 0.2rem var(--se--shadow);
+	box-shadow: 0 0 0 0.2rem var(--se--shadow);
 	transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
@@ -259,7 +429,7 @@
 .sun-editor button:disabled {
 	cursor: not-allowed;
 	background-color: inherit;
-	color: #bdbdbd;
+	color: var(--se--disabled);
 }
 
 /* dropdown layer - list button */
@@ -276,9 +446,21 @@
 	text-align: left;
 }
 
-.sun-editor .se-btn-list.default_value {
-	background-color: #f3f3f3;
-	border: 1px dotted #e1e1e1;
+.sun-editor .se-btn-list:focus,
+.sun-editor .se-btn-list:hover {
+	background-color: var(--se--hover);
+	border: 1px dotted var(--se--border-light);
+}
+
+.sun-editor .se-btn-list.default-value {
+	background-color: var(--se--list-default-value-bg);
+	border: 1px dotted var(--se--border-light);
+}
+
+.sun-editor .se-btn-list.default-value:focus,
+.sun-editor .se-btn-list.default-value:hover {
+	background-color: var(--se--hover);
+	border: 1px dotted var(--se--border-light);
 }
 
 /** --- Icons ---------------------------------------------------------- */
@@ -287,7 +469,7 @@
 	fill: currentColor;
 }
 
-.sun-editor button > svg,
+.sun-editor button>svg,
 .sun-editor .se-svg {
 	width: 14px;
 	height: 14px;
@@ -299,21 +481,21 @@
 }
 
 /* close class icon */
-.sun-editor .close > svg,
-.sun-editor .se-modal-close > svg {
+.sun-editor .close>svg,
+.sun-editor .se-modal-close>svg {
 	width: 10px;
 	height: 10px;
 }
 
 /* se-select-btn icon */
-.sun-editor .se-btn-select > svg {
+.sun-editor .se-btn-select>svg {
 	float: right;
 	width: 8px;
 	height: 8px;
 }
 
 /* se-btn-list inner icon */
-.sun-editor .se-btn-list > .se-list-icon {
+.sun-editor .se-btn-list>.se-list-icon {
 	display: inline-block;
 	width: 16px;
 	height: 16px;
@@ -322,13 +504,13 @@
 }
 
 /* se-line-breaker inner icon */
-.sun-editor .se-line-breaker > button > svg {
+.sun-editor .se-line-breaker>button>svg {
 	width: 22px;
 	height: 22px;
 }
 
 /* icon class */
-.sun-editor button > i::before {
+.sun-editor button>i::before {
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 	display: inline-block;
@@ -339,7 +521,7 @@
 	line-height: 2;
 }
 
-.sun-editor button > [class='se-icon-text'] {
+.sun-editor button>[class='se-icon-text'] {
 	font-size: 20px;
 	line-height: 1;
 }
@@ -367,28 +549,28 @@
 .sun-editor .se-arrow.se-arrow-up {
 	top: -12px;
 	border-top-width: 0;
-	border-bottom-color: #999;
+	border-bottom-color: var(--se--border);
 }
 
 .sun-editor .se-arrow.se-arrow-up::after {
 	top: 1px;
 	content: ' ';
 	border-top-width: 0;
-	border-bottom-color: #fff;
+	border-bottom-color: var(--se--border-light);
 }
 
 /* arrow down */
 .sun-editor .se-arrow.se-arrow-down {
 	bottom: -12px;
 	border-bottom-width: 0;
-	border-top-color: #999;
+	border-top-color: var(--se--border);
 }
 
 .sun-editor .se-arrow.se-arrow-down::after {
 	top: -12px;
 	content: ' ';
 	border-bottom-width: 0;
-	border-top-color: #fff;
+	border-top-color: var(--se--border-light);
 }
 
 /** --- container */
@@ -406,7 +588,7 @@
 	height: 100%;
 	top: 0;
 	left: 0;
-	background-color: #fff;
+	background-color: var(--se--editable-bg);
 	opacity: 0.7;
 	filter: alpha(opacity=70);
 	z-index: 2147483647;
@@ -419,7 +601,7 @@
 	left: 50%;
 	height: 44px;
 	width: 44px;
-	border-top: 2px solid #07d;
+	border-top: 2px solid var(--se--border-light);
 	border-right: 2px solid transparent;
 	border-radius: 50%;
 	animation: spinner 0.8s linear infinite;
@@ -433,11 +615,11 @@
 	width: 100%;
 	height: 1px;
 	cursor: text;
-	border-top: 2px solid #3288ff;
+	border-top: 2px solid var(--se--line-breaker-border-top);
 	z-index: 7;
 }
 
-.sun-editor .se-line-breaker > button.se-btn {
+.sun-editor .se-line-breaker>button.se-btn {
 	position: relative;
 	display: inline-block;
 	width: 28px;
@@ -445,17 +627,17 @@
 	top: -15px;
 	float: none;
 	left: -50%;
-	color: #fff;
-	background-color: #4592ff;
-	border: 1px solid #3288ff;
+	color: var(--se--line-breaker-btn-color);
+	background-color: var(--se--line-breaker-btn-bg);
+	border: 1px solid var(--se--line-breaker-btn-border);
 	opacity: 0.75;
 	cursor: pointer;
 }
 
-.sun-editor .se-line-breaker > button.se-btn:hover {
-	color: #fff;
-	background-color: #4592ff;
-	border: 1px solid #3288ff;
+.sun-editor .se-line-breaker>button.se-btn:hover {
+	color: var(--se--line-breaker-btn-hover-color);
+	background-color: var(--se--line-breaker-btn-hover-bg);
+	border: 1px solid var(--se--line-breaker-btn-hover-border);
 	opacity: 0.9;
 }
 
@@ -465,9 +647,9 @@
 	display: none;
 	width: 22px;
 	height: 22px;
-	color: #fff;
-	background-color: #4592ff;
-	border: 1px solid #3288ff;
+	color: var(--se--line-breaker-component-color);
+	background-color: var(--se--line-breaker-component-bg);
+	border: 1px solid var(--se--line-breaker-component-border);
 	opacity: 0.75;
 	border-radius: 2px;
 	cursor: pointer;
@@ -487,8 +669,8 @@
 	overflow: visible;
 	padding: 0;
 	margin: 0;
-	background-color: #fff;
-	outline: 1px solid #e1e1e1;
+	background-color: var(--se--component-bg);
+	outline: 1px solid var(--se--outline);
 	z-index: 7;
 }
 
@@ -519,8 +701,8 @@
 .sun-editor .se-toolbar.se-toolbar-inline {
 	display: none;
 	position: absolute;
-	box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-	-webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+	box-shadow: 0 3px 9px var(--se--shadow);
+	-webkit-box-shadow: 0 3px 9px var(--se--shadow);
 }
 
 /* balloon toolbar */
@@ -529,8 +711,8 @@
 	position: absolute;
 	z-index: 2147483647;
 	width: auto;
-	box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-	-webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+	box-shadow: 0 3px 9px var(--se--shadow);
+	-webkit-box-shadow: 0 3px 9px var(--se--shadow);
 }
 
 /* sticky toolbar */
@@ -547,20 +729,20 @@
 
 /* toolbar arrow up */
 .sun-editor .se-toolbar .se-arrow.se-arrow-up {
-	border-bottom-color: #e1e1e1;
+	border-bottom-color: var(--se--border-light);
 }
 
 .sun-editor .se-toolbar .se-arrow.se-arrow-up::after {
-	border-bottom-color: #fff;
+	border-bottom-color: var(--se--border-light);
 }
 
 /* toolbar arrow down */
 .sun-editor .se-toolbar .se-arrow.se-arrow-down {
-	border-top-color: #e1e1e1;
+	border-top-color: var(--se--border-light);
 }
 
 .sun-editor .se-toolbar .se-arrow.se-arrow-down::after {
-	border-top-color: #fff;
+	border-top-color: var(--se--border-light);
 }
 
 /** --- tool bar --- module --- button, module, group ----------------------------------------------------------  */
@@ -570,7 +752,7 @@
 }
 
 .sun-editor .se-btn-module-border {
-	border: 1px solid #e1e1e1;
+	border: 1px solid var(--se--border-light);
 	border-radius: 2px;
 	margin-left: 1px;
 	margin-right: 1px;
@@ -588,12 +770,12 @@
 /* ---more - layer */
 .sun-editor .se-toolbar-more-layer {
 	margin: 0 -3px;
-	background-color: #fff;
+	background-color: var(--se--component-bg);
 }
 
 .sun-editor .se-toolbar-more-layer .se-more-layer {
 	display: none;
-	border-top: 1px solid #e1e1e1;
+	border-top: 1px solid var(--se--border-light);
 }
 
 .sun-editor .se-toolbar-more-layer .se-more-layer .se-more-form {
@@ -636,7 +818,7 @@
 	margin-right: 4px;
 }
 
-.sun-editor .se-btn-select.on .txt + svg {
+.sun-editor .se-btn-select.on .txt+svg {
 	transform: rotate(-180deg);
 }
 
@@ -688,12 +870,12 @@
 	left: 0px;
 	height: auto;
 	z-index: 5;
-	border: 1px solid #e1e1e1;
+	border: 1px solid var(--se--border-light);
 	border-radius: 2px;
 	padding: 4px;
-	background-color: #fff;
-	-webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-	box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+	background-color: var(--se--component-bg);
+	-webkit-box-shadow: 0 3px 9px var(--se--shadow);
+	box-shadow: 0 3px 9px var(--se--shadow);
 	outline: 0 none;
 }
 
@@ -714,7 +896,7 @@
 	margin: auto;
 }
 
-.sun-editor .se-list-inner li > button {
+.sun-editor .se-list-inner li>button {
 	min-width: 100%;
 	width: max-content;
 }
@@ -724,21 +906,44 @@
 	width: 100%;
 }
 
+.sun-editor .se-list-inner .se-list-basic li button.active {
+	background-color: var(--se--active-bg);
+	border: 1px solid var(--se--active-border);
+	border-left: 0;
+	border-right: 0;
+}
+
+.sun-editor .se-list-inner .se-list-basic li button.active:hover {
+	background-color: var(--se--active-hover-bg);
+	border: 1px solid var(--se--active-border);
+	border-left: 0;
+	border-right: 0;
+}
+
+.sun-editor .se-list-inner .se-list-basic li button.active:active {
+	background-color: var(--se--active-hover-bg);
+	border: 1px solid var(--se--active-border);
+	border-left: 0;
+	border-right: 0;
+	-webkit-box-shadow: inset 0 3px 5px var(--se--active-border);
+	box-shadow: inset 0 3px 5px var(--se--active-border);
+}
+
 /* dropdown layer - checked list */
 .sun-editor .se-list-inner .se-list-checked li .se-svg {
 	float: left;
 	padding: 6px 6px 0 0;
 }
 
-.sun-editor .se-list-inner .se-list-checked li .se-svg > svg {
+.sun-editor .se-list-inner .se-list-checked li .se-svg>svg {
 	display: none;
 }
 
 .sun-editor .se-list-inner .se-list-checked li.se-checked * {
-	color: #4592ff;
+	color: var(--se--editable-a-hover);
 }
 
-.sun-editor .se-list-inner .se-list-checked li.se-checked .se-svg > svg {
+.sun-editor .se-list-inner .se-list-checked li.se-checked .se-svg>svg {
 	display: block;
 }
 
@@ -755,7 +960,7 @@
 }
 
 .sun-editor .se-list-layer.se-list-font-family .default {
-	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid var(--se--border);
 }
 
 /* dropdown layer - hr */
@@ -836,13 +1041,13 @@
 
 .sun-editor .se-list-layer.se-list-format ul blockquote {
 	font-size: 13px;
-	color: #999;
+	color: var(--se--blockquote-color);
 	height: 22px;
 	margin: 0;
 	background-color: transparent;
 	line-height: 1.5;
 	border-style: solid;
-	border-color: #b1b1b1;
+	border-color: var(--se--border);
 	padding: 0 0 0 7px;
 	border-width: 0;
 	border-left-width: 5px;
@@ -850,11 +1055,11 @@
 
 .sun-editor .se-list-layer.se-list-format ul pre {
 	font-size: 13px;
-	color: #666;
+	color: var(--se--editable-pre-color);
 	padding: 4px 11px;
 	margin: 0;
-	background-color: #f9f9f9;
-	border: 1px solid #e1e1e1;
+	background-color: var(--se--editable-pre-bg);
+	border: 1px solid var(--se--border-light);
 	border-radius: 2px;
 }
 
@@ -871,13 +1076,13 @@
 	font-size: 14px;
 	text-align: left;
 	list-style: none;
-	background-color: #fff;
+	background-color: var(--se--component-bg);
 	-webkit-background-clip: padding-box;
 	background-clip: padding-box;
-	border: 1px solid #ccc;
+	border: 1px solid var(--se--border);
 	border-radius: 2px;
-	-webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-	box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+	-webkit-box-shadow: 0 6px 12px var(--se--shadow);
+	box-shadow: 0 6px 12px var(--se--shadow);
 }
 
 .sun-editor .se-selector-table .se-table-size {
@@ -900,8 +1105,7 @@
 	font-size: 18px;
 	width: 1em;
 	height: 1em;
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAZdEVYdFNvZnR3YXJlAEFkb2JlIEltYWdlUmVhZHlxyWU8AAADJmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4gPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS42LWMxNDIgNzkuMTYwOTI0LCAyMDE3LzA3LzEzLTAxOjA2OjM5ICAgICAgICAiPiA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPiA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDo4QTZCNzMzN0I3RUYxMUU4ODcwQ0QwMjM1NTgzRTJDNyIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDo4QTZCNzMzNkI3RUYxMUU4ODcwQ0QwMjM1NTgzRTJDNyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ0MgMjAxOCAoV2luZG93cykiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo0MzYyNEUxRUI3RUUxMUU4ODZGQzgwRjNBODgyNTdFOSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo0MzYyNEUxRkI3RUUxMUU4ODZGQzgwRjNBODgyNTdFOSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pl0yAuwAAABBSURBVDhPY/wPBAxUAGCDGvdBeWSAeicIDTfIXREiQArYeR9hEBOEohyMGkQYjBpEGAxjg6ib+yFMygCVvMbAAABj0hwMTNeKJwAAAABJRU5ErkJggg==')
-		repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAZdEVYdFNvZnR3YXJlAEFkb2JlIEltYWdlUmVhZHlxyWU8AAADJmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4gPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS42LWMxNDIgNzkuMTYwOTI0LCAyMDE3LzA3LzEzLTAxOjA2OjM5ICAgICAgICAiPiA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPiA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDo4QTZCNzMzN0I3RUYxMUU4ODcwQ0QwMjM1NTgzRTJDNyIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDo4QTZCNzMzNkI3RUYxMUU4ODcwQ0QwMjM1NTgzRTJDNyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ0MgMjAxOCAoV2luZG93cykiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo0MzYyNEUxRUI3RUUxMUU4ODZGQzgwRjNBODgyNTdFOSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo0MzYyNEUxRkI3RUUxMUU4ODZGQzgwRjNBODgyNTdFOSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pl0yAuwAAABBSURBVDhPY/wPBAxUAGCDGvdBeWSAeicIDTfIXREiQArYeR9hEBOEohyMGkQYjBpEGAxjg6ib+yFMygCVvMbAAABj0hwMTNeKJwAAAABJRU5ErkJggg==') repeat;
 }
 
 .sun-editor .se-selector-table .se-table-size-unhighlighted {
@@ -910,8 +1114,7 @@
 	font-size: 18px;
 	width: 10em;
 	height: 10em;
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASAgMAAAAroGbEAAAACVBMVEUAAIj4+Pjp6ekKlAqjAAAAAXRSTlMAQObYZgAAAAFiS0dEAIgFHUgAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfYAR0BKhmnaJzPAAAAG0lEQVQI12NgAAOtVatWMTCohoaGUY+EmIkEAEruEzK2J7tvAAAAAElFTkSuQmCC')
-		repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASAgMAAAAroGbEAAAACVBMVEUAAIj4+Pjp6ekKlAqjAAAAAXRSTlMAQObYZgAAAAFiS0dEAIgFHUgAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfYAR0BKhmnaJzPAAAAG0lEQVQI12NgAAOtVatWMTCohoaGUY+EmIkEAEruEzK2J7tvAAAAAElFTkSuQmCC') repeat;
 }
 
 .sun-editor .se-selector-table .se-table-size-display {
@@ -958,7 +1161,7 @@
 .sun-editor .se-list-layer .se-selector-color .se-color-pallet button.active,
 .sun-editor .se-list-layer .se-selector-color .se-color-pallet button:hover,
 .sun-editor .se-list-layer .se-selector-color .se-color-pallet button:focus {
-	border: 3px solid #fff;
+	border: 3px solid var(--se--border-light);
 }
 
 /** --- form group - input -------------------------------------------------------------- */
@@ -979,7 +1182,7 @@
 	margin: 1px 0 1px 0;
 	padding: 0;
 	border-radius: 0.25rem;
-	border: 1px solid #ccc;
+	border: 1px solid var(--se--form-group-input-border);
 }
 
 .sun-editor .se-form-group button,
@@ -992,10 +1195,10 @@
 
 .sun-editor .se-form-group button.se-btn,
 .sun-editor .se-form-group button.se-btn {
-	border: 1px solid #ccc;
+	border: 1px solid var(--se--form-group-btn-border);
 }
 
-.sun-editor .se-form-group > div {
+.sun-editor .se-form-group>div {
 	position: relative;
 }
 
@@ -1022,7 +1225,7 @@
 .sun-editor .se-dropdown .se-form-group input {
 	width: auto;
 	height: 33px;
-	color: #555;
+	color: var(--se--form-group-input-color);
 }
 
 .sun-editor .se-dropdown .se-form-group .se-color-input {
@@ -1030,12 +1233,12 @@
 	margin: 0 2px;
 	text-transform: uppercase;
 	border: none;
-	border-bottom: 2px solid #b1b1b1;
+	border-bottom: 2px solid var(--se--form-group-color-input-border-bottom);
 	outline: none;
 }
 
 .sun-editor .se-dropdown .se-form-group .se-color-input:focus {
-	border-bottom: 3px solid #b1b1b1;
+	border-bottom: 3px solid var(--se--form-group-color-input-focus-border-bottom);
 }
 
 /** --- editor area */
@@ -1067,8 +1270,8 @@
 }
 
 .sun-editor .se-wrapper .se-wrapper-code {
-	background-color: #191919;
-	color: #fff;
+	background-color: var(--se--wrapper-code);
+	color: var(--se--wrapper-code-color);
 	font-size: 13px;
 	word-break: break-all;
 	padding: 4px;
@@ -1081,7 +1284,7 @@
 }
 
 .sun-editor-editable .katex.se-focus {
-	outline: 1px solid #80bdff;
+	outline: 1px solid var(--se--outline);
 }
 
 /** --- placeholder */
@@ -1091,7 +1294,7 @@
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	z-index: 1;
-	color: #b1b1b1;
+	color: var(--se--wrapper-placeholder-color);
 	font-size: 13px;
 	line-height: 1.5;
 	top: 0;
@@ -1116,9 +1319,9 @@
 	width: auto;
 	height: auto;
 	min-height: 16px;
-	border-top: 1px solid #e1e1e1;
+	border-top: 1px solid var(--se--border-light);
 	padding: 0 4px;
-	background-color: #fff;
+	background-color: var(--se--status-bar-bg);
 	cursor: ns-resize;
 }
 
@@ -1149,12 +1352,12 @@
 	position: relative;
 	width: auto;
 	height: auto;
-	color: #666;
+	color: var(--se--status-bar-color);
 	margin: 0;
 	padding: 0;
 	font-size: 10px;
 	line-height: 1.5;
-	background: transparent;
+	background-color: transparent;
 }
 
 /** status bar - charCounter */
@@ -1166,13 +1369,13 @@
 	height: auto;
 	margin: 0;
 	padding: 0;
-	color: #999;
+	color: var(--se--status-bar-color);
 	font-size: 13px;
-	background: transparent;
+	background-color: transparent;
 }
 
 .sun-editor .se-status-bar .se-char-counter-wrapper.se-blink {
-	color: #b94a48;
+	color: var(--se--error-color);
 	animation: blinker 0.2s linear infinite;
 }
 
@@ -1196,7 +1399,7 @@
 .sun-editor .se-modal button {
 	font-size: 14px;
 	line-height: 1.5;
-	color: #111;
+	color: var(--se--modal-color);
 	margin: 0;
 }
 
@@ -1206,7 +1409,7 @@
 	height: 100%;
 	top: 0;
 	left: 0;
-	background-color: #222;
+	background-color: var(--se--modal-back-bg);
 	opacity: 0.5;
 }
 
@@ -1225,14 +1428,14 @@
 	width: auto;
 	max-width: 500px;
 	margin: 1.75rem auto;
-	background-color: #fff;
+	background-color: var(--se--modal-content-bg);
 	-webkit-background-clip: padding-box;
 	background-clip: padding-box;
-	border: 1px solid rgba(0, 0, 0, 0.2);
+	border: 1px solid var(--se--modal-content-border);
 	border-radius: 2px;
 	outline: 0;
-	-webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-	box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+	-webkit-box-shadow: 0 3px 9px var(--se--modal-content-shadow);
+	box-shadow: 0 3px 9px var(--se--modal-content-shadow);
 }
 
 @media screen and (max-width: 509px) {
@@ -1266,13 +1469,13 @@
 .sun-editor .se-modal .se-modal-inner .se-modal-header {
 	height: 50px;
 	padding: 6px 15px 6px 15px;
-	border-bottom: 1px solid #e5e5e5;
+	border-bottom: 1px solid var(--se--modal-header-border);
 }
 
 .sun-editor .se-modal .se-modal-inner .se-modal-header .se-modal-close {
 	float: right;
 	font-weight: bold;
-	text-shadow: 0 1px 0 #fff;
+	text-shadow: 0 1px 0 var(--se--modal-header-close-text-shadow);
 	filter: alpha(opacity=100);
 	opacity: 1;
 }
@@ -1301,7 +1504,7 @@
 }
 
 .sun-editor .se-modal .se-modal-inner input:disabled {
-	background-color: #f3f3f3;
+	background-color: var(--se--modal-input-disabled-bg);
 }
 
 .sun-editor .se-modal .se-modal-inner .se-modal-size-text {
@@ -1329,15 +1532,15 @@
 	min-height: 55px;
 	padding: 10px 15px 0px 15px;
 	text-align: right;
-	border-top: 1px solid #e5e5e5;
+	border-top: 1px solid var(--se--modal-footer-border-top);
 }
 
-.sun-editor .se-modal .se-modal-inner .se-modal-footer > div {
+.sun-editor .se-modal .se-modal-inner .se-modal-footer>div {
 	float: left;
 	line-height: 1.7;
 }
 
-.sun-editor .se-modal .se-modal-inner .se-modal-footer > div > label {
+.sun-editor .se-modal .se-modal-inner .se-modal-footer>div>label {
 	margin: 0 5px 0 0;
 }
 
@@ -1351,8 +1554,8 @@
 	margin-right: 4px;
 }
 
-.sun-editor .se-modal .se-modal-inner .se-modal-btn-check:disabled + span {
-	color: #999;
+.sun-editor .se-modal .se-modal-inner .se-modal-btn-check:disabled+span {
+	color: var(--se--modal-btn-check-color);
 }
 
 .sun-editor .se-modal .se-modal-inner .se-modal-form-footer .se-modal-btn-check {
@@ -1372,17 +1575,17 @@
 	align-items: center;
 }
 
-.sun-editor .se-modal .se-modal-inner .se-modal-form .se-modal-form-files > input {
+.sun-editor .se-modal .se-modal-inner .se-modal-form .se-modal-form-files>input {
 	flex: auto;
 }
 
 .sun-editor .se-modal .se-modal-inner .se-modal-form .se-modal-form-files .se-modal-files-edge-button {
 	flex: auto;
 	opacity: 0.8;
-	border: 1px solid #ccc;
+	border: 1px solid var(--se--modal-files-edge-button-border);
 }
 
-.sun-editor .se-modal .se-modal-inner .se-modal-form .se-modal-form-files .se-modal-files-edge-button.se-file-remove > svg {
+.sun-editor .se-modal .se-modal-inner .se-modal-form .se-modal-form-files .se-modal-files-edge-button.se-file-remove>svg {
 	width: 8px;
 	height: 8px;
 }
@@ -1421,7 +1624,7 @@
 
 .sun-editor .se-modal .se-modal-inner .se-modal-form .se-input-form.se-input-url:disabled {
 	text-decoration: line-through;
-	color: #999;
+	color: var(--se--disabled);
 }
 
 .sun-editor .se-modal .se-modal-inner .se-modal-form .se-video-ratio {
@@ -1430,25 +1633,25 @@
 }
 
 .sun-editor .se-modal .se-modal-inner .se-modal-form a {
-	color: #004cff;
+	color: var(--se--modal-form-a-color);
 }
 
 /* modal - revert button */
 .sun-editor .se-modal .se-modal-inner .se-modal-btn-revert {
 	float: right;
-	border: 1px solid #ccc;
+	border: 1px solid var(--se--border);
 }
 
 /* modal - inner tab */
 .sun-editor .se-modal-tabs {
 	width: 100%;
 	height: 25px;
-	border-bottom: 1px solid #e5e5e5;
+	border-bottom: 1px solid var(--se--modal-tabs-border-bottom);
 }
 
 .sun-editor .se-modal-tabs button {
-	background-color: #e5e5e5;
-	border-right: 1px solid #e5e5e5;
+	background-color: var(--se--modal-tabs-button-bg);
+	border-right: 1px solid var(--se--modal-tabs-button-border-right);
 	float: left;
 	outline: none;
 	padding: 2px 13px;
@@ -1456,11 +1659,11 @@
 }
 
 .sun-editor .se-modal-tabs button:hover {
-	background-color: #fff;
+	background-color: var(--se--modal-tabs-button-hover-bg);
 }
 
 .sun-editor .se-modal-tabs button.active {
-	background-color: #fff;
+	background-color: var(--se--modal-tabs-button-active-bg);
 	border-bottom: 0;
 }
 
@@ -1468,7 +1671,7 @@
 .sun-editor .se-modal .se-modal-inner .se-modal-form .se-input-form.se-math-exp {
 	resize: vertical;
 	height: 14em;
-	border: 1px solid #3f9dff;
+	border: 1px solid var(--se--modal-math-exp-border);
 	font-size: 13px;
 	padding: 4px;
 	direction: ltr;
@@ -1484,26 +1687,26 @@
 	font-size: 13px;
 }
 
-.sun-editor .se-modal .se-modal-inner .se-modal-form .se-math-preview > span {
+.sun-editor .se-modal .se-modal-inner .se-modal-form .se-math-preview>span {
 	display: inline-block;
-	-webkit-box-shadow: 0 0 0 0.1rem #d0e3ff;
-	box-shadow: 0 0 0 0.1rem #d0e3ff;
+	-webkit-box-shadow: 0 0 0 0.1rem var(--se--modal-math-preview-span-shadow);
+	box-shadow: 0 0 0 0.1rem var(--se--modal-math-preview-span-shadow);
 }
 
-.sun-editor .se-modal .se-modal-inner .se-modal-form .se-math-preview > span * {
+.sun-editor .se-modal .se-modal-inner .se-modal-form .se-math-preview>span * {
 	direction: ltr;
 }
 
-.sun-editor .se-modal .se-modal-inner .se-modal-form .se-math-preview > .se-math-katex-error {
-	color: #b94a48;
-	-webkit-box-shadow: 0 0 0 0.1rem #f2dede;
-	box-shadow: 0 0 0 0.1rem #f2dede;
+.sun-editor .se-modal .se-modal-inner .se-modal-form .se-math-preview>.se-math-katex-error {
+	color: var(--se--error-color);
+	-webkit-box-shadow: 0 0 0 0.1rem var(--se--error-shadow);
+	box-shadow: 0 0 0 0.1rem var(--se--error-shadow);
 }
 
-.sun-editor .se-modal .se-modal-inner .se-modal-form .se-math-preview > .se-math-katex-error svg {
+.sun-editor .se-modal .se-modal-inner .se-modal-form .se-math-preview>.se-math-katex-error svg {
 	width: auto;
 	height: 30px;
-	color: #b94a48;
+	color: var(--se--error-color);
 }
 
 /* modal - modal - link preview */
@@ -1515,7 +1718,7 @@
 	padding-top: 2px;
 	font-weight: normal;
 	font-family: inherit;
-	color: #666;
+	color: var(--se--modal-link-preview-color);
 	background-color: transparent;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -1535,7 +1738,7 @@
 	display: none;
 	line-height: 1;
 	margin: 2px;
-	color: #4592ff;
+	color: var(--se--a-color);
 }
 
 .sun-editor .se-modal .se-modal-inner .se-anchor-preview-form .se-link-preview {
@@ -1551,7 +1754,7 @@
 
 .sun-editor .se-modal .se-modal-inner .se-anchor-rel-btn {
 	width: 46px;
-	color: #3f9dff;
+	color: var(--se--modal-anchor-rel-btn-color);
 }
 
 .sun-editor .se-modal .se-modal-inner .se-anchor-rel-wrapper {
@@ -1564,11 +1767,6 @@
 	text-align: left;
 }
 
-/* .sun-editor .se-modal .se-modal-inner .se-modal-form .se-mention-item {line-height:28px;min-height:25px;padding:0 5px;cursor:pointer;}
-.sun-editor .se-modal .se-modal-inner .se-modal-form .se-mention-item:hover {background-color:#e1e1e1}
-.sun-editor .se-modal .se-modal-inner .se-modal-form .se-mention-item.se-mention-active {background-color: #d1d1d1; border-radius:3px;}
-.sun-editor .se-modal .se-modal-inner .se-modal-form .se-mention-search {margin-bottom: 10px;} */
-
 /** --- controller ---------------------------------------------------------- */
 .sun-editor .se-controller {
 	position: absolute;
@@ -1577,7 +1775,7 @@
 	z-index: 2147483646;
 	padding: 2px 2px 0 2px;
 	margin: 0;
-	border: 1px solid #999;
+	border: 1px solid var(--se--border);
 	text-align: start;
 	text-decoration: none;
 	text-shadow: none;
@@ -1587,11 +1785,11 @@
 	word-spacing: normal;
 	word-wrap: normal;
 	white-space: normal;
-	background-color: #fff;
+	background-color: var(--se--component-bg);
 	-webkit-background-clip: padding-box;
 	background-clip: padding-box;
-	-webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-	box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+	-webkit-box-shadow: 0 5px 10px var(--se--shadow);
+	box-shadow: 0 5px 10px var(--se--shadow);
 	line-break: auto;
 }
 
@@ -1600,10 +1798,10 @@
 }
 
 .sun-editor .sun-editor-editable[contenteditable='true'] .se-component.se-component-copy {
-	background-color: #d1d1d1;
+	background-color: var(--se--component-bg);
 	opacity: 0.3;
-	-webkit-box-shadow: 0 0 0 0.5rem #1275ff;
-	box-shadow: 0 0 0 0.5rem #1275ff;
+	-webkit-box-shadow: 0 0 0 0.5rem var(--se--shadow);
+	box-shadow: 0 0 0 0.5rem var(--se--shadow);
 	transition: box-shadow 0.15s ease-in-out;
 }
 
@@ -1683,68 +1881,68 @@
 .sun-editor .se-resizing-container .se-resize-dot {
 	position: absolute;
 	display: inline-block;
-	outline: 3px solid #80bdff;
+	outline: 3px solid var(--se--resize-dot);
 	border: 0;
 	padding: 0;
 }
 
 .sun-editor .se-resizing-container.se-resize-ing .se-resize-dot {
-	outline: 3px solid #4592ff;
+	outline: 3px solid var(--se--resize-dot);
 }
 
-.sun-editor .se-resizing-container .se-resize-dot > span {
+.sun-editor .se-resizing-container .se-resize-dot>span {
 	position: absolute;
 	pointer-events: auto;
 	width: 8px;
 	height: 8px;
 	border-radius: 1px;
-	background-color: #4592ff;
-	border: 1px solid #4592ff;
+	background-color: var(--se--resize-dot-span-bg);
+	border: 1px solid var(--se--resize-dot-span-border);
 }
 
-.sun-editor .se-resizing-container .se-resize-dot > span.tl {
+.sun-editor .se-resizing-container .se-resize-dot>span.tl {
 	top: -6px;
 	left: -6px;
 	cursor: nw-resize;
 }
 
-.sun-editor .se-resizing-container .se-resize-dot > span.tr {
+.sun-editor .se-resizing-container .se-resize-dot>span.tr {
 	top: -6px;
 	right: -6px;
 	cursor: ne-resize;
 }
 
-.sun-editor .se-resizing-container .se-resize-dot > span.bl {
+.sun-editor .se-resizing-container .se-resize-dot>span.bl {
 	bottom: -6px;
 	left: -6px;
 	cursor: sw-resize;
 }
 
-.sun-editor .se-resizing-container .se-resize-dot > span.br {
+.sun-editor .se-resizing-container .se-resize-dot>span.br {
 	right: -6px;
 	bottom: -6px;
 	cursor: se-resize;
 }
 
-.sun-editor .se-resizing-container .se-resize-dot > span.lw {
+.sun-editor .se-resizing-container .se-resize-dot>span.lw {
 	left: -8px;
 	bottom: 50%;
 	cursor: w-resize;
 }
 
-.sun-editor .se-resizing-container .se-resize-dot > span.th {
+.sun-editor .se-resizing-container .se-resize-dot>span.th {
 	left: 50%;
 	top: -8px;
 	cursor: n-resize;
 }
 
-.sun-editor .se-resizing-container .se-resize-dot > span.rw {
+.sun-editor .se-resizing-container .se-resize-dot>span.rw {
 	right: -8px;
 	bottom: 50%;
 	cursor: e-resize;
 }
 
-.sun-editor .se-resizing-container .se-resize-dot > span.bh {
+.sun-editor .se-resizing-container .se-resize-dot>span.bh {
 	right: 50%;
 	bottom: -8px;
 	cursor: s-resize;
@@ -1759,8 +1957,8 @@
 	padding: 5px;
 	margin: 2px;
 	font-size: 12px;
-	color: #fff;
-	background-color: #333;
+	color: var(--se--resize-display-color);
+	background-color: var(--se--resize-display-bg);
 	border-radius: 2px;
 	opacity: 0.75;
 }
@@ -1809,7 +2007,7 @@
 
 .sun-editor .se-controller-link .link-content a {
 	display: inline-block;
-	color: #4592ff;
+	color: var(--se--a-color);
 	max-width: 200px;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -1830,13 +2028,13 @@
 	height: auto;
 	overflow-y: auto;
 	overflow-x: hidden;
-	background-color: #fff;
+	background-color: var(--se--select-menu-bg);
 	border-radius: 2px;
 	padding: 2px 0;
 	margin: 0;
-	border: 1px solid #bababa;
-	-webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-	box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+	border: 1px solid var(--se--border);
+	-webkit-box-shadow: 0 3px 9px var(--se--shadow);
+	box-shadow: 0 3px 9px var(--se--shadow);
 	outline: 0 none;
 	overflow-y: inherit;
 	overflow-x: inherit;
@@ -1869,31 +2067,32 @@
 	margin: 0;
 	min-height: 28px;
 }
+
 .sun-editor .se-select-menu .se-select-item button span {
 	padding: 0;
 	margin: 0;
 }
 
 .sun-editor .se-select-menu .se-select-item *.se-select-on {
-	color: #4592ff;
+	color: var(--se--select-item-on-color);
 }
 
 .sun-editor .se-select-menu.se-select-menu-mouse-move .se-select-item:hover,
 .sun-editor .se-select-menu:not(.se-select-menu-mouse-move) .se-select-item.active {
-	border-color: #d0e3ff !important;
-	outline: 1px solid #3288ff !important;
-	-webkit-box-shadow: 0 0 0 0.3rem #d0e3ff;
-	box-shadow: 0 0 0 0.3rem #d0e3ff;
+	border-color: var(--se--select-item-hover-border) !important;
+	outline: 1px solid var(--se--select-item-hover-outline) !important;
+	-webkit-box-shadow: 0 0 0 0.3rem var(--se--select-item-hover-shadow);
+	box-shadow: 0 0 0 0.3rem var(--se--select-item-hover-shadow);
 	transition: box-shadow 0.1s ease-in-out;
 }
 
 .sun-editor .se-select-menu.se-select-menu-mouse-move .se-select-item:active,
 .sun-editor .se-select-menu.se-select-menu-mouse-move .se-select-item.__se__active {
-	background-color: #dbeaff;
-	border-color: #dbeaff !important;
-	outline: 1px solid #3288ff !important;
-	-webkit-box-shadow: inset 2px 2px 5px #b7ccf2, inset -2px -2px 5px #e6f2ff;
-	box-shadow: inset 2px 2px 5px #b7ccf2, inset -2px -2px 5px #e6f2ff;
+	background-color: var(--se--select-item-active-bg);
+	border-color: var(--se--select-item-active-border) !important;
+	outline: 1px solid var(--se--select-item-active-outline) !important;
+	-webkit-box-shadow: inset 2px 2px 5px var(--se--select-item-active-shadow1), inset -2px -2px 5px var(--se--select-item-active-shadow2);
+	box-shadow: inset 2px 2px 5px var(--se--select-item-active-shadow1), inset -2px -2px 5px var(--se--select-item-active-shadow2);
 	transition: background-color 0.1s ease-in-out, box-shadow 0.1s ease-in-out;
 }
 
@@ -1922,7 +2121,7 @@
 .sun-editor .se-file-browser button {
 	font-size: 14px;
 	line-height: 1.5;
-	color: #111;
+	color: var(--se--file-browser-color);
 	margin: 0;
 }
 
@@ -1933,7 +2132,7 @@
 	height: 100%;
 	top: 0;
 	left: 0;
-	background-color: #222;
+	background-color: var(--se--file-browser-back-bg);
 	opacity: 0.5;
 }
 
@@ -1951,14 +2150,14 @@
 	width: 960px;
 	max-width: 100%;
 	margin: 20px auto;
-	background-color: #fff;
+	background-color: var(--se--file-browser-content-bg);
 	-webkit-background-clip: padding-box;
 	background-clip: padding-box;
-	border: 1px solid rgba(0, 0, 0, 0.2);
+	border: 1px solid var(--se--file-browser-content-border);
 	border-radius: 2px;
 	outline: 0;
-	-webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-	box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+	-webkit-box-shadow: 0 3px 9px var(--se--shadow);
+	box-shadow: 0 3px 9px var(--se--shadow);
 }
 
 /* --- browser - header */
@@ -1966,18 +2165,18 @@
 	height: auto;
 	min-height: 50px;
 	padding: 6px 15px 6px 15px;
-	border-bottom: 1px solid #e5e5e5;
+	border-bottom: 1px solid var(--se--file-browser-header-border-bottom);
 }
 
 .sun-editor .se-file-browser .se-file-browser-header .se-file-browser-close {
 	float: right;
 	font-weight: bold;
-	text-shadow: 0 1px 0 #fff;
+	text-shadow: 0 1px 0 var(--se--file-browser-header-close-text-shadow);
 	filter: alpha(opacity=100);
 	opacity: 1;
 }
 
-.sun-editor .se-file-browser .se-file-browser-header .se-file-browser-close > svg {
+.sun-editor .se-file-browser .se-file-browser-header .se-file-browser-close>svg {
 	width: 12px;
 	height: 12px;
 }
@@ -2002,10 +2201,10 @@
 
 .sun-editor .se-file-browser .se-file-browser-tags a {
 	display: inline-block;
-	background-color: #f5f5f5;
+	background-color: var(--se--file-browser-tags-a-bg);
 	padding: 6px 12px;
 	margin: 8px 0 8px 8px;
-	color: #333;
+	color: var(--se--file-browser-tags-a-color);
 	text-decoration: none;
 	border-radius: 32px;
 	-moz-border-radius: 32px;
@@ -2017,24 +2216,24 @@
 }
 
 .sun-editor .se-file-browser .se-file-browser-tags a:hover {
-	background-color: #e1e1e1;
+	background-color: var(--se--file-browser-tags-a-hover-bg);
 }
 
 .sun-editor .se-file-browser .se-file-browser-tags a:active {
-	background-color: #d1d1d1;
+	background-color: var(--se--file-browser-tags-a-active);
 }
 
 .sun-editor .se-file-browser .se-file-browser-tags a.on {
-	background-color: #ebf3fe;
-	color: #4592ff;
+	background-color: var(--se--file-browser-tags-a-on-bg);
+	color: var(--se--file-browser-tags-a-on-color);
 }
 
 .sun-editor .se-file-browser .se-file-browser-tags a.on:hover {
-	background-color: #d8e8fe;
+	background-color: var(--se--file-browser-tags-a-on-hover);
 }
 
 .sun-editor .se-file-browser .se-file-browser-tags a.on:active {
-	background-color: #d0e3ff;
+	background-color: var(--se--file-browser-tags-a-on-active-bg);
 }
 
 /* --- browser - body */
@@ -2103,11 +2302,11 @@
 
 .sun-editor .se-file-browser .se-file-browser-list.se-image-list .se-file-item-img:hover {
 	opacity: 0.8;
-	-webkit-box-shadow: 0 0 0 0.2rem #3288ff;
-	box-shadow: 0 0 0 0.2rem #3288ff;
+	-webkit-box-shadow: 0 0 0 0.2rem var(--se--file-browser-list-hover-shadow);
+	box-shadow: 0 0 0 0.2rem var(--se--file-browser-list-hover-shadow);
 }
 
-.sun-editor .se-file-browser .se-file-browser-list.se-image-list .se-file-item-img > img {
+.sun-editor .se-file-browser .se-file-browser-list.se-image-list .se-file-item-img>img {
 	position: relative;
 	display: block;
 	width: 100%;
@@ -2116,11 +2315,11 @@
 	height: auto;
 }
 
-.sun-editor .se-file-browser .se-file-browser-list.se-image-list .se-file-item-img > .se-file-name-image {
+.sun-editor .se-file-browser .se-file-browser-list.se-image-list .se-file-item-img>.se-file-name-image {
 	position: absolute;
 	z-index: 1;
 	font-size: 13px;
-	color: #fff;
+	color: var(--se--file-browser-file-name-image-color);
 	left: 0px;
 	bottom: 0;
 	padding: 5px 10px;
@@ -2132,8 +2331,8 @@
 	pointer-events: none;
 }
 
-.sun-editor .se-file-browser .se-file-browser-list.se-image-list .se-file-item-img > .se-file-name-image.se-file-name-back {
-	background-color: #333;
+.sun-editor .se-file-browser .se-file-browser-list.se-image-list .se-file-item-img>.se-file-name-image.se-file-name-back {
+	background-color: var(--se--file-browser-name-back-bg);
 	opacity: 0.6;
 	pointer-events: none;
 }
@@ -2148,13 +2347,13 @@
 	height: auto;
 	margin: 1.75rem auto;
 	border-radius: 2px;
-	-webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-	box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+	-webkit-box-shadow: 0 3px 9px var(--se--shadow);
+	box-shadow: 0 3px 9px var(--se--shadow);
 	word-break: break-all;
-	color: #b94a48;
-	background-color: #fff;
+	color: var(--se--notice-color);
+	background-color: var(--se--editable-bg);
 	padding: 15px;
-	border: 1px solid rgba(0, 0, 0, 0.2);
+	border: 1px solid var(--se--border);
 }
 
 .sun-editor .se-notice button {
@@ -2176,7 +2375,7 @@
 	height: auto;
 	top: 120%;
 	left: 50%;
-	background: transparent;
+	background-color: transparent;
 	opacity: 0;
 	z-index: 1;
 	line-height: 1.5;
@@ -2201,8 +2400,8 @@
 	margin: 0;
 	padding: 4px 6px;
 	border-radius: 2px;
-	background-color: #333;
-	color: #fff;
+	background-color: var(--se--tooltip-bg);
+	color: var(--se--tooltip-color);
 	text-align: center;
 	line-height: unset;
 	white-space: nowrap;
@@ -2217,7 +2416,7 @@
 	margin-left: -5px;
 	border-width: 5px;
 	border-style: solid;
-	border-color: transparent transparent #333 transparent;
+	border-color: transparent transparent var(--se--tooltip-border) transparent;
 }
 
 .sun-editor .se-tooltip:hover .se-tooltip-inner {
@@ -2233,7 +2432,7 @@
 	display: none !important;
 }
 
-.sun-editor .se-tooltip .se-tooltip-inner .se-tooltip-text .se-shortcut > .se-shortcut-key {
+.sun-editor .se-tooltip .se-tooltip-inner .se-tooltip-text .se-shortcut>.se-shortcut-key {
 	display: inline;
 	font-weight: bold;
 }
@@ -2268,7 +2467,7 @@
 	text-align: right;
 }
 
-.sun-editor.se-rtl .se-btn-list > .se-list-icon {
+.sun-editor.se-rtl .se-btn-list>.se-list-icon {
 	margin: -1px 0 0 10px;
 }
 
@@ -2301,7 +2500,7 @@
 }
 
 /* dropdown layer - checked list */
-.sun-editor.se-rtl .se-list-inner .se-list-checked li button > .se-svg {
+.sun-editor.se-rtl .se-list-inner .se-list-checked li button>.se-svg {
 	float: right;
 	padding: 6px 0 0 6px;
 }
@@ -2353,11 +2552,11 @@
 	float: left;
 }
 
-.sun-editor.se-rtl .se-modal .se-modal-inner .se-modal-footer > div {
+.sun-editor.se-rtl .se-modal .se-modal-inner .se-modal-footer>div {
 	float: right;
 }
 
-.sun-editor.se-rtl .se-modal .se-modal-inner .se-modal-footer > div > label {
+.sun-editor.se-rtl .se-modal .se-modal-inner .se-modal-footer>div>label {
 	margin: 0 0 0 5px;
 }
 
@@ -2418,6 +2617,7 @@
 	margin-right: -11px;
 	margin-left: 0;
 }
+
 /** --- RTL end -------------------------------------------------------------------------------------------------------------------------------------------------- */
 
 /** button module float --------------------------------------------- */
@@ -2431,16 +2631,16 @@
 
 /** --- error ---------------------------------------------------------- */
 .sun-editor .se-error {
-	color: #d9534f;
+	color: var(--se--error-color);
 }
 
 .sun-editor input.se-error:focus,
 select.se-error:focus,
 textarea.se-error:focus {
-	border: 1px solid #f2dede;
+	border: 1px solid var(--se--error-shadow);
 	outline: 0;
-	-webkit-box-shadow: 0 0 0 0.2rem #eed3d7;
-	box-shadow: 0 0 0 0.2rem #eed3d7;
+	-webkit-box-shadow: 0 0 0 0.2rem var(--se--error-shadow);
+	box-shadow: 0 0 0 0.2rem var(--se--error-shadow);
 	transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
@@ -2471,72 +2671,61 @@ textarea.se-error:focus {
 .sun-editor-editable.se-show-block ol,
 .sun-editor-editable.se-show-block ul,
 .sun-editor-editable.se-show-block pre {
-	border: 1px dashed #3f9dff !important;
+	border: 1px dashed var(--se--show-block-border) !important;
 	padding: 14px 8px 8px 8px !important;
 }
 
 .sun-editor-editable.se-show-block ol,
 .sun-editor-editable.se-show-block ul {
-	border: 1px dashed #d539ff !important;
+	border: 1px dashed var(--se--show-block-ol) !important;
 }
 
 .sun-editor-editable.se-show-block pre {
-	border: 1px dashed #27c022 !important;
+	border: 1px dashed var(--se--show-block-pre) !important;
 }
 
 .se-show-block p {
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAPAQMAAAAF7dc0AAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAaSURBVAjXY/j/gwGCPvxg+F4BQiAGDP1HQQByxxw0gqOzIwAAAABJRU5ErkJggg==')
-		no-repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAPAQMAAAAF7dc0AAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAaSURBVAjXY/j/gwGCPvxg+F4BQiAGDP1HQQByxxw0gqOzIwAAAABJRU5ErkJggg==') no-repeat;
 }
 
 .se-show-block div {
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABUAAAAPAQMAAAAxlBYoAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAmSURBVAjXY/j//wcDDH+8XsHwDYi/hwNx1A8w/nYLKH4XoQYJAwCXnSgcl2MOPgAAAABJRU5ErkJggg==')
-		no-repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABUAAAAPAQMAAAAxlBYoAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAmSURBVAjXY/j//wcDDH+8XsHwDYi/hwNx1A8w/nYLKH4XoQYJAwCXnSgcl2MOPgAAAABJRU5ErkJggg==') no-repeat;
 }
 
 .se-show-block h1 {
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAPAQMAAAA4f7ZSAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAfSURBVAjXY/j/v4EBhr+9B+LzEPrDeygfhI8j1CBhAEhmJGY4Rf6uAAAAAElFTkSuQmCC')
-		no-repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAPAQMAAAA4f7ZSAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAfSURBVAjXY/j/v4EBhr+9B+LzEPrDeygfhI8j1CBhAEhmJGY4Rf6uAAAAAElFTkSuQmCC') no-repeat;
 }
 
 .se-show-block h2 {
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAPAQMAAAA4f7ZSAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAmSURBVAjXY/j/v4EBhr+dB+LtQPy9geEDEH97D8T3gbgdoQYJAwA51iPuD2haEAAAAABJRU5ErkJggg==')
-		no-repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAPAQMAAAA4f7ZSAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAmSURBVAjXY/j/v4EBhr+dB+LtQPy9geEDEH97D8T3gbgdoQYJAwA51iPuD2haEAAAAABJRU5ErkJggg==') no-repeat;
 }
 
 .se-show-block h3 {
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAPAQMAAAA4f7ZSAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAiSURBVAjXY/j/v4EBhr+dB+LtQPy9geHDeQgN5p9HqEHCADeWI+69VG2MAAAAAElFTkSuQmCC')
-		no-repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAPAQMAAAA4f7ZSAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAiSURBVAjXY/j/v4EBhr+dB+LtQPy9geHDeQgN5p9HqEHCADeWI+69VG2MAAAAAElFTkSuQmCC') no-repeat;
 }
 
 .se-show-block h4 {
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAPAQMAAADTSA1RAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAiSURBVAjXY/j//wADDH97DsTXIfjDdiDdDMTfIRhZHRQDAKJOJ6L+K3y7AAAAAElFTkSuQmCC')
-		no-repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAPAQMAAADTSA1RAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAiSURBVAjXY/j//wADDH97DsTXIfjDdiDdDMTfIRhZHRQDAKJOJ6L+K3y7AAAAAElFTkSuQmCC') no-repeat;
 }
 
 .se-show-block h5 {
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAPAQMAAAA4f7ZSAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAlSURBVAjXY/j/v4EBhr+1A/F+IO5vYPiwHUh/B2IQfR6hBgkDABlWIy5uM+9GAAAAAElFTkSuQmCC')
-		no-repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAPAQMAAAA4f7ZSAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAlSURBVAjXY/j/v4EBhr+1A/F+IO5vYPiwHUh/B2IQfR6hBgkDABlWIy5uM+9GAAAAAElFTkSuQmCC') no-repeat;
 }
 
 .se-show-block h6 {
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAPAQMAAAA4f7ZSAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAiSURBVAjXY/j/v4EBhr+dB+LtQLy/geFDP5S9HSKOrA6KAR9GIza1ptJnAAAAAElFTkSuQmCC')
-		no-repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAPAQMAAAA4f7ZSAAAABlBMVEWAgID////n1o2sAAAAAnRSTlP/AOW3MEoAAAAiSURBVAjXY/j/v4EBhr+dB+LtQLy/geFDP5S9HSKOrA6KAR9GIza1ptJnAAAAAElFTkSuQmCC') no-repeat;
 }
 
 .se-show-block li {
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAPCAYAAADkmO9VAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAA7SURBVDhPYxgFcNDQ0PAfykQBIHEYhgoRB/BpwCfHBKWpBkaggYxQGgOgBzyQD1aLLA4TGwWDGjAwAACR3RcEU9Ui+wAAAABJRU5ErkJggg==')
-		no-repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAPCAYAAADkmO9VAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAA7SURBVDhPYxgFcNDQ0PAfykQBIHEYhgoRB/BpwCfHBKWpBkaggYxQGgOgBzyQD1aLLA4TGwWDGjAwAACR3RcEU9Ui+wAAAABJRU5ErkJggg==') no-repeat;
 }
 
 .se-show-block ol {
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAMCAYAAABiDJ37AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABHSURBVDhPYxgFcNDQ0PAfhKFcFIBLHCdA1oBNM0kGEmMAPgOZoDTVANUNxAqQvURMECADRiiNAWCagDSGGhyW4DRrMAEGBgAu0SX6WpGgjAAAAABJRU5ErkJggg==')
-		no-repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAMCAYAAABiDJ37AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABHSURBVDhPYxgFcNDQ0PAfhKFcFIBLHCdA1oBNM0kGEmMAPgOZoDTVANUNxAqQvURMECADRiiNAWCagDSGGhyW4DRrMAEGBgAu0SX6WpGgjAAAAABJRU5ErkJggg==') no-repeat;
 }
 
 .se-show-block ul {
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAMCAYAAABiDJ37AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAA1SURBVDhPYxgFDA0NDf+hTBSALI5LDQgwQWmqgVEDKQcsUBoF4ItFGEBXA+QzQpmDGjAwAAA8DQ4Lni6gdAAAAABJRU5ErkJggg==')
-		no-repeat;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAMCAYAAABiDJ37AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAA1SURBVDhPYxgFDA0NDf+hTBSALI5LDQgwQWmqgVEDKQcsUBoF4ItFGEBXA+QzQpmDGjAwAAA8DQ4Lni6gdAAAAABJRU5ErkJggg==') no-repeat;
 }
 
 /** --- controller wrapper ---------------------------------------------------------- */
@@ -2562,4 +2751,607 @@ textarea.se-error:focus {
 	to {
 		transform: rotate(361deg);
 	}
+}
+
+/* suneditor content */
+.sun-editor-editable {
+	font-family: var(--se-font-sans-serif);
+	font-size: 13px;
+	color: var(--se--editable-color);
+	background-color: var(--se--editable-bg);
+	line-height: 1.5;
+	word-break: normal;
+	word-wrap: break-word;
+	padding: 16px;
+	margin: 0;
+}
+
+.sun-editor-editable * {
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+	font-family: inherit;
+	font-size: inherit;
+	color: inherit;
+}
+
+/* RTL - editable */
+.sun-editor-editable.se-rtl,
+.sun-editor-editable.se-rtl * {
+	direction: rtl;
+}
+
+.sun-editor-editable .se-component>figure {
+	direction: initial;
+}
+
+/** controllers on tag */
+.sun-editor-editable td,
+.sun-editor-editable th,
+.sun-editor-editable figure,
+.sun-editor-editable figcaption,
+.sun-editor-editable img,
+.sun-editor-editable iframe,
+.sun-editor-editable video,
+.sun-editor-editable audio {
+	position: relative;
+}
+
+/** span */
+.sun-editor-editable span {
+	display: inline;
+	vertical-align: baseline;
+	margin: 0;
+	padding: 0;
+}
+
+/* katex */
+.sun-editor-editable span.katex {
+	display: inline-block;
+}
+
+.sun-editor-editable span.katex * {
+	direction: ltr;
+}
+
+/* a */
+.sun-editor-editable a {
+	color: var(--se--editable-a-color);
+	text-decoration: none;
+}
+
+.sun-editor-editable span[style~='color:'] a {
+	color: inherit;
+}
+
+.sun-editor-editable a:hover,
+.sun-editor-editable a:focus {
+	cursor: pointer;
+	color: var(--se--editable-a-hover);
+	text-decoration: underline;
+}
+
+.sun-editor-editable a.on {
+	color: var(--se--editable-a-hover);
+	background-color: var(--se--editable-a-on);
+}
+
+/* pre */
+.sun-editor-editable pre {
+	display: block;
+	padding: 8px;
+	margin: 0 0 10px;
+	font-family: var(--se-font-monospace);
+	color: var(--se--editable-pre-color);
+	line-height: 1.45;
+	background-color: var(--se--editable-pre-bg);
+	border: 1px solid var(--se--border-light);
+	border-radius: 2px;
+	white-space: pre-wrap !important;
+	word-wrap: break-word;
+	overflow: visible;
+}
+
+/* ol, ul */
+.sun-editor-editable ol {
+	list-style-position: outside;
+	display: block;
+	list-style-type: decimal;
+	margin-block-start: 1em;
+	margin-block-end: 1em;
+	margin-inline-start: 0px;
+	margin-inline-end: 0px;
+	padding-inline-start: 40px;
+}
+
+.sun-editor-editable ul {
+	list-style-position: outside;
+	display: block;
+	list-style-type: disc;
+	margin-block-start: 1em;
+	margin-block-end: 1em;
+	margin-inline-start: 0px;
+	margin-inline-end: 0px;
+	padding-inline-start: 40px;
+}
+
+.sun-editor-editable li {
+	display: list-item;
+	text-align: -webkit-match-parent;
+	margin-bottom: 5px;
+}
+
+/* nested list ol, ul */
+.sun-editor-editable ol ol,
+.sun-editor-editable ol ul,
+.sun-editor-editable ul ol,
+.sun-editor-editable ul ul {
+	margin: 0;
+}
+
+.sun-editor-editable ol ol,
+.sun-editor-editable ul ol {
+	list-style-type: lower-alpha;
+}
+
+.sun-editor-editable ol ol ol,
+.sun-editor-editable ul ol ol,
+.sun-editor-editable ul ul ol {
+	list-style-type: upper-roman;
+}
+
+.sun-editor-editable ul ul,
+.sun-editor-editable ol ul {
+	list-style-type: circle;
+}
+
+.sun-editor-editable ul ul ul,
+.sun-editor-editable ol ul ul,
+.sun-editor-editable ol ol ul {
+	list-style-type: square;
+}
+
+/* sub, sup */
+.sun-editor-editable sub,
+.sun-editor-editable sup {
+	font-size: 75%;
+	line-height: 0;
+}
+
+.sun-editor-editable sub {
+	vertical-align: sub;
+}
+
+.sun-editor-editable sup {
+	vertical-align: super;
+}
+
+/** format style */
+/* p */
+.sun-editor-editable p {
+	display: block;
+	margin: 0 0 10px;
+}
+
+/* div */
+.sun-editor-editable div {
+	display: block;
+	margin: 0;
+	padding: 0;
+}
+
+/* blockquote */
+.sun-editor-editable blockquote {
+	display: block;
+	font-family: inherit;
+	font-size: inherit;
+	color: var(--se--border);
+	margin-block-start: 1em;
+	margin-block-end: 1em;
+	margin-inline-start: 0;
+	margin-inline-end: 0;
+	border-style: solid;
+	border-width: 0;
+	padding-top: 0;
+	padding-bottom: 0;
+	border-color: var(--se--blockquote-border);
+	padding-left: 20px;
+	padding-right: 5px;
+	border-left-width: 5px;
+	border-right-width: 0px;
+}
+
+.sun-editor-editable blockquote blockquote {
+	border-color: var(--se--blockquote-border);
+}
+
+.sun-editor-editable blockquote blockquote blockquote {
+	border-color: var(--se--blockquote-border);
+}
+
+.sun-editor-editable blockquote blockquote blockquote blockquote {
+	border-color: var(--se--blockquote-border);
+}
+
+/* RTL - blockquote */
+.sun-editor-editable.se-rtl blockquote {
+	padding-left: 5px;
+	padding-right: 20px;
+	border-left-width: 0px;
+	border-right-width: 5px;
+}
+
+/* h1 */
+.sun-editor-editable h1 {
+	display: block;
+	font-size: 2em;
+	margin-block-start: 0.67em;
+	margin-block-end: 0.67em;
+	margin-inline-start: 0px;
+	margin-inline-end: 0px;
+	font-weight: bold;
+}
+
+/* h2 */
+.sun-editor-editable h2 {
+	display: block;
+	font-size: 1.5em;
+	margin-block-start: 0.83em;
+	margin-block-end: 0.83em;
+	margin-inline-start: 0px;
+	margin-inline-end: 0px;
+	font-weight: bold;
+}
+
+/* h3 */
+.sun-editor-editable h3 {
+	display: block;
+	font-size: 1.17em;
+	margin-block-start: 1em;
+	margin-block-end: 1em;
+	margin-inline-start: 0px;
+	margin-inline-end: 0px;
+	font-weight: bold;
+}
+
+/* h4 */
+.sun-editor-editable h4 {
+	display: block;
+	font-size: 1em;
+	margin-block-start: 1.33em;
+	margin-block-end: 1.33em;
+	margin-inline-start: 0px;
+	margin-inline-end: 0px;
+	font-weight: bold;
+}
+
+/* h5 */
+.sun-editor-editable h5 {
+	display: block;
+	font-size: 0.83em;
+	margin-block-start: 1.67em;
+	margin-block-end: 1.67em;
+	margin-inline-start: 0px;
+	margin-inline-end: 0px;
+	font-weight: bold;
+}
+
+/* h6 */
+.sun-editor-editable h6 {
+	display: block;
+	font-size: 0.67em;
+	margin-block-start: 2.33em;
+	margin-block-end: 2.33em;
+	margin-inline-start: 0px;
+	margin-inline-end: 0px;
+	font-weight: bold;
+}
+
+/* hr */
+.sun-editor-editable hr {
+	display: flex;
+	border-width: 1px 0 0;
+	border-color: var(--se--editable-hr);
+	border-image: initial;
+	height: 1px;
+}
+
+.sun-editor-editable hr.__se__solid {
+	border-style: solid none none;
+}
+
+.sun-editor-editable hr.__se__dotted {
+	border-style: dotted none none;
+}
+
+.sun-editor-editable hr.__se__dashed {
+	border-style: dashed none none;
+}
+
+.sun-editor-editable hr.on {
+	border-color: var(--se--a-color);
+	-webkit-box-shadow: 0 0 0 0.1rem var(--se--shadow);
+	box-shadow: 0 0 0 0.1rem var(--se--shadow);
+}
+
+/* table */
+.sun-editor-editable table {
+	display: table;
+	table-layout: auto !important;
+	border: 1px solid var(--se--editable-table-border);
+	width: 100%;
+	max-width: 100%;
+	margin: 0 0 10px;
+	background-color: transparent;
+	border-spacing: 0;
+	border-collapse: collapse;
+}
+
+/* RTL - table */
+.sun-editor-editable.se-rtl table {
+	margin: 0 0 10px auto;
+}
+
+.sun-editor-editable table thead {
+	border-bottom: 2px solid var(--se--editable-table-thead);
+}
+
+.sun-editor-editable table tr {
+	border: 1px solid var(--se--editable-table-tr-border);
+}
+
+.sun-editor-editable table th {
+	background-color: var(--se--editable-table-th-bg);
+}
+
+.sun-editor-editable table th,
+.sun-editor-editable table td {
+	border: 1px solid var(--se--editable-table-th-border);
+	padding: 0.4em;
+	background-clip: padding-box;
+}
+
+/** table style class */
+.sun-editor-editable table.se-table-size-auto {
+	width: auto !important;
+}
+
+.sun-editor-editable table.se-table-size-100 {
+	width: 100% !important;
+}
+
+.sun-editor-editable table.se-table-layout-auto {
+	table-layout: auto !important;
+}
+
+.sun-editor-editable table.se-table-layout-fixed {
+	table-layout: fixed !important;
+}
+
+/** table - select class */
+.sun-editor-editable table td.se-table-selected-cell,
+.sun-editor-editable table th.se-table-selected-cell {
+	outline: 1px double var(--se--a-color);
+}
+
+.sun-editor-editable.se-disabled * {
+	user-select: none;
+	-o-user-select: none;
+	-moz-user-select: none;
+	-khtml-user-select: none;
+	-webkit-user-select: none;
+	-ms-user-select: none;
+}
+
+/** component (image, iframe video) */
+.sun-editor-editable .se-component {
+	display: flex;
+	padding: 1px;
+	margin: 0 0 10px;
+	background-color: inherit;
+}
+
+.sun-editor-editable[contenteditable='true'] .se-component {
+	outline: 1px dashed var(--se--outline);
+}
+
+/* float */
+.sun-editor-editable .__se__float-left {
+	float: left;
+	margin-right: 4px;
+}
+
+.sun-editor-editable .__se__float-right {
+	float: right;
+	margin-left: 4px;
+}
+
+.sun-editor-editable .__se__float-center {
+	float: center;
+}
+
+.sun-editor-editable .__se__float-none {
+	float: none;
+}
+
+/** image, video .. */
+.sun-editor-editable img,
+.sun-editor-editable iframe,
+.sun-editor-editable video,
+.sun-editor-editable audio {
+	display: block;
+	margin: 0;
+	padding: 0;
+	width: auto;
+	height: auto;
+	max-width: 100%;
+}
+
+/*  image, video - select index  */
+.sun-editor-editable[contenteditable='true']:not(.se-read-only) figure::after {
+	position: absolute;
+	content: '';
+	z-index: 1;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	cursor: default;
+	display: block;
+	background-color: transparent;
+}
+
+.sun-editor-editable[contenteditable='true'] figure a,
+.sun-editor-editable[contenteditable='true'] figure img,
+.sun-editor-editable[contenteditable='true'] figure iframe,
+.sun-editor-editable[contenteditable='true'] figure video {
+	z-index: 0;
+}
+
+.sun-editor-editable[contenteditable='true'] figure figcaption {
+	display: block;
+	z-index: 2;
+}
+
+.sun-editor-editable[contenteditable='true'] figure figcaption:focus {
+	border-color: var(--se--figcaption-focus-border);
+	outline: 0;
+	-webkit-box-shadow: 0 0 0 0.2rem var(--se--shadow);
+	box-shadow: 0 0 0 0.2rem var(--se--shadow);
+}
+
+/** image, video iframe figure cover */
+.sun-editor-editable .se-image-container,
+.sun-editor-editable .se-video-container {
+	width: auto;
+	height: auto;
+	max-width: 100%;
+}
+
+.sun-editor-editable figure {
+	display: block;
+	outline: none;
+	padding: 0;
+	margin: 0;
+}
+
+.sun-editor-editable .__se__float-left figure,
+.sun-editor-editable .__se__float-right figure,
+.sun-editor-editable .__se__float-center figure {
+	margin: auto !important;
+}
+
+.sun-editor-editable figure figcaption {
+	padding: 1em 0.5em;
+	margin: 0;
+	background-color: var(--se--figcaption-bg);
+	outline: none;
+}
+
+.sun-editor-editable figure figcaption p {
+	line-height: 2;
+	margin: 0;
+}
+
+/* image */
+.sun-editor-editable .se-image-container a img {
+	padding: 1px;
+	margin: 1px;
+	outline: 1px solid var(--se--outline);
+}
+
+/** video */
+.sun-editor-editable .se-video-container iframe,
+.sun-editor-editable .se-video-container video {
+	outline: 1px solid var(--se--outline);
+	position: absolute;
+	top: 0;
+	left: 0;
+	border: 0;
+	width: 100%;
+	height: 100%;
+}
+
+.sun-editor-editable .se-video-container figure {
+	left: 0px;
+	width: 100%;
+	max-width: 100%;
+}
+
+/** audio */
+.sun-editor-editable audio {
+	width: 300px;
+	height: 54px;
+}
+
+.sun-editor-editable audio.active {
+	outline: 2px solid var(--se--outline);
+}
+
+/** -- Paragraph styles custom -- */
+/* Bordered */
+.sun-editor-editable .__se__p-bordered,
+.sun-editor .__se__p-bordered {
+	border-top: solid 1px var(--se--border);
+	border-bottom: solid 1px var(--se--border);
+	padding: 4px 0;
+}
+
+/* Spaced */
+.sun-editor-editable .__se__p-spaced,
+.sun-editor .__se__p-spaced {
+	letter-spacing: 1px;
+}
+
+/* Neon (https://codepen.io/GeorgePark/pen/MrjbEr) */
+.sun-editor-editable .__se__p-neon,
+.sun-editor .__se__p-neon {
+	font-weight: 200;
+	font-style: italic;
+	background: var(--se--p-neon-bg);
+	color: var(--se--p-neon-color);
+	padding: 6px 4px;
+	border: 2px solid var(--se--p-neon-border);
+	border-radius: 6px;
+	text-transform: uppercase;
+	animation: neonFlicker 1.5s infinite alternate;
+}
+
+@keyframes neonFlicker {
+
+	0%,
+	19%,
+	21%,
+	23%,
+	25%,
+	54%,
+	56%,
+	100% {
+		text-shadow: -0.2rem -0.2rem 1rem var(--se--p-neon-flicker-text-shadow), 0.2rem 0.2rem 1rem var(--se--p-neon-flicker-text-shadow), 0 0 2px var(--se--p-neon-flicker-txt), 0 0 4px var(--se--p-neon-flicker-txt), 0 0 6px var(--se--p-neon-flicker-txt), 0 0 8px var(--se--p-neon-flicker-txt), 0 0 10px var(--se--p-neon-flicker-txt);
+		box-shadow: 0 0 0.5px var(--se--p-neon-flicker-box-shadow), inset 0 0 0.5px var(--se--p-neon-flicker-box-shadow), 0 0 2px var(--se--p-neon-flicker-box), inset 0 0 2px var(--se--p-neon-flicker-box), 0 0 4px var(--se--p-neon-flicker-box), inset 0 0 4px var(--se--p-neon-flicker-box);
+	}
+
+	20%,
+	24%,
+	55% {
+		text-shadow: none;
+		box-shadow: none;
+	}
+}
+
+/* -- Text styles custom -- */
+/* Shadow */
+.sun-editor-editable .__se__t-shadow,
+.sun-editor .__se__t-shadow {
+	text-shadow: -0.2rem -0.2rem 1rem var(--se--editable-t-code-text-shadow6), 0.2rem 0.2rem 1rem var(--se--editable-t-code-text-shadow6), 0 0 0.2rem var(--se--editable-t-code-text-shadow1), 0 0 0.4rem var(--se--editable-t-code-text-shadow2), 0 0 0.6rem var(--se--editable-t-code-text-shadow3), 0 0 0.8rem var(--se--editable-t-code-text-shadow4), 0 0 1rem var(--se--editable-t-code-text-shadow5);
+}
+
+/* Code */
+.sun-editor-editable .__se__t-code,
+.sun-editor .__se__t-code {
+	font-family: var(--se-font-monospace);
+	color: var(--se--editable-t-code-color);
+	background-color: var(--se--editable-t-code-bg);
+	border-radius: 6px;
+	padding: 0.2em 0.4em;
 }

--- a/src/plugins/dropdown/font.js
+++ b/src/plugins/dropdown/font.js
@@ -89,7 +89,7 @@ function CreateHTML(editor, fontList) {
 	let list =
 		'<div class="se-list-inner">' +
 		'<ul class="se-list-basic">' +
-		'<li><button type="button" class="se-btn se-btn-list default_value" title="' +
+		'<li><button type="button" class="se-btn se-btn-list default-value" title="' +
 		lang.default +
 		'" aria-label="' +
 		lang.default +

--- a/src/plugins/dropdown/fontSize.js
+++ b/src/plugins/dropdown/fontSize.js
@@ -87,7 +87,7 @@ function CreateHTML(editor, items) {
 	let list =
 		'<div class="se-list-inner">' +
 		'<ul class="se-list-basic">' +
-		'<li><button type="button" class="se-btn se-btn-list default_value" title="' +
+		'<li><button type="button" class="se-btn se-btn-list default-value" title="' +
 		lang.default +
 		'" aria-label="' +
 		lang.default +

--- a/src/plugins/dropdown/lineHeight.js
+++ b/src/plugins/dropdown/lineHeight.js
@@ -89,7 +89,7 @@ function CreateHTML(editor, items) {
 	let list =
 		'<div class="se-list-inner">' +
 		'<ul class="se-list-basic">' +
-		'<li><button type="button" class="default_value se-btn-list" title="' +
+		'<li><button type="button" class="default-value se-btn-list" title="' +
 		lang.default +
 		'" aria-label="' +
 		lang.default +


### PR DESCRIPTION
WHAT WAS DONE?

The css has been restructured to allow the simplified use of themes through color variables. That way, each theme only needs to overwrite the colors in ":root" or create a new configuration.

WHAT DO YOU NEED TO MODIFY/ADD TO THE CODE?
-------------------------------------------------- ------------------------------------------
- Include a "theme" option. For example: 

`const initEditor=suneditor.init({ "name-of-theme": "light/dark/yellow/blue/...", ...`

- Add "`<body data-se-theme="name-of-theme">`"

TO CREATE A NEW THEME
------------------------------------------------
- Duplicate the section "[data-se-theme="light"]" with a new name and change the desired colors.
- As an additional suggestion, you can create themes in separate .js files and include the desired theme file in the application's header, just as you do with language files.

Only this is needed.