### PR TITLE
fix(_cleanStyle): fix for when window.getComputedStyle(context.element.wysiwyg) does not contain style tag

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -5320,7 +5320,7 @@ export default function (context, pluginCallButtons, plugins, lang, options, _re
                         r = style[i].match(/([a-zA-Z0-9-]+)(:)([^"']+)/);
                         if (r && !/inherit|initial|revert|unset/i.test(r[3])) {
                             const k = util.kebabToCamelCase(r[1].trim());
-                            const v = this.wwComputedStyle[k].replace(/"/g, '');
+                            const v = this.wwComputedStyle[k]?.replace?.(/"/g, '');
                             const c = r[3].trim();
                             switch (k) {
                                 case 'fontFamily':


### PR DESCRIPTION
fix for when window.getComputedStyle(context.element.wysiwyg) does not contain style tag

I have a .docx file that contains an element with a style tag mso-element that does not exist in the getComputedStyle resulting in 
this.wwComputedStyle[k] being undefined and calling replace on it breaks the editor content. My users were saving a react-hook-form and the editor contents were always empty.

I have attached the [word document](https://github.com/user-attachments/files/16191573/test.docx) that breaks the editor. Try to Ctr + A and Ctrl + C, paste the contents in the editor and see the console.

v2.46.4