### PR TITLE
Improve types for media uploadHandler callbacks

### DIFF
--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -679,7 +679,14 @@ type MediaUploadHandlerParam = {
     size?: string
   }[]
 }
-type MediaUploadHandlerFunc = (param: MediaUploadHandlerParam | File[] | string | undefined) => void
+/**
+ * Function that takes a parameter of *any one* of the below
+ * - Result: An object of type MediaUploadHandlerParam: {result: {url, name, size}[]}
+ * - File[]: Array of files, handled by suneditor(refer to docs for imageUploadUrl option)
+ * - string: In case of errors
+ * - no param: Just finish, nothing to do
+ */
+type MediaUploadHandlerFunc = (param?: MediaUploadHandlerParam | File[] | string) => void
 type MediaUploadHandlerErrorResult = {
   'limitSize': number,
   'uploadSize': number


### PR DESCRIPTION
Type for `uploadHandler` function for `onImageUploadBefore` etc callbacks seems to be less constrained.
Currently, if I try to pass a result object, we get something like
<img width="400" alt="Screenshot 2025-06-16 at 00 30 35" src="https://github.com/user-attachments/assets/8242f018-23cc-40ee-b4c5-7d224387880a" />


After this update for types:
<img width="400" alt="Screenshot 2025-06-16 at 00 51 30" src="https://github.com/user-attachments/assets/eb16f696-f6bd-487a-8c8e-93a0ccb9e013" />


If I try to pass a result object without `url` for example
<img width="400" alt="Screenshot 2025-06-16 at 00 52 22" src="https://github.com/user-attachments/assets/bbbc9ead-f945-4f06-8c3c-8b52c928d1a7" />


Code sample showing that it accepts param types of all 4 cases(ResultObj, File[], string, nothing)
<img width="400" alt="Screenshot 2025-06-16 at 01 11 46" src="https://github.com/user-attachments/assets/d46248dc-2541-4813-9e76-dc62b3029108" />



Looking at the usage of these files in `image.js:submitAction()` etc, 
the `size` field seems to be optional(it works without passing size in my case)
Please let me know if I should make the size field non-optional in any case(image, audio, video)