### PR TITLE
fix: guard codeWrapper in fullscreen when codeView is omitted

### DIFF
--- a/src/core/logic/panel/viewer.js
+++ b/src/core/logic/panel/viewer.js
@@ -300,7 +300,7 @@ class Viewer {
 			this.#originCssText = topArea.style.cssText;
 			this.#editorAreaOriginCssText = editorArea.style.cssText;
 			this.#wysiwygOriginCssText = wysiwygFrame.style.cssText;
-			this.#codeWrapperOriginCssText = codeWrapper.style.cssText;
+			this.#codeWrapperOriginCssText = codeWrapper?.style.cssText;
 			this.#codeOriginCssText = code.style.cssText;
 			this.#codeNumberOriginCssText = codeNumbers?.style.cssText;
 			this.#markdownWrapperOriginCssText = markdownWrapper?.style.cssText;
@@ -344,9 +344,11 @@ class Viewer {
 			wysiwygFrame.style.cssText = (wysiwygFrame.style.cssText.match(/\s?display(\s+)?:(\s+)?[a-zA-Z]+;/) || [''])[0] + this.#frameOptions.get('_defaultStyles').editor + (isCodeView || isMarkdownView ? 'display: none;' : '');
 
 			// code wrapper
-			codeWrapper.style.cssText = (codeWrapper.style.cssText.match(/\s?display(\s+)?:(\s+)?[a-zA-Z]+;/) || [''])[0] + `display: ${!isCodeView ? 'none' : 'flex'} !important;`;
-			codeWrapper.style.overflow = 'auto';
-			codeWrapper.style.height = '100%';
+			if (codeWrapper) {
+				codeWrapper.style.cssText = (codeWrapper.style.cssText.match(/\s?display(\s+)?:(\s+)?[a-zA-Z]+;/) || [''])[0] + `display: ${!isCodeView ? 'none' : 'flex'} !important;`;
+				codeWrapper.style.overflow = 'auto';
+				codeWrapper.style.height = '100%';
+			}
 
 			// markdown wrapper
 			if (markdownWrapper) {
@@ -384,7 +386,9 @@ class Viewer {
 			wysiwygFrame.style.cssText = this.#wysiwygOriginCssText.replace(/\s?display(\s+)?:(\s+)?[a-zA-Z]+;/, '') + (isCodeView || isMarkdownView ? 'display: none;' : '');
 
 			// code wrapper
-			codeWrapper.style.cssText = this.#codeWrapperOriginCssText.replace(/\s?display(\s+)?:(\s+)?[a-zA-Z]+;/, '') + `display: ${!isCodeView ? 'none' : 'flex'} !important;`;
+			if (codeWrapper) {
+				codeWrapper.style.cssText = this.#codeWrapperOriginCssText.replace(/\s?display(\s+)?:(\s+)?[a-zA-Z]+;/, '') + `display: ${!isCodeView ? 'none' : 'flex'} !important;`;
+			}
 
 			// code
 			code.style.cssText = this.#codeOriginCssText;


### PR DESCRIPTION
Full Screen 플러그인 기능을 Code View 플러그인 없이 작동하면 
CodeWrapper 값이 존재하지 않아 ```null```.style 을 조회하는 문제가 발생합니다.

```Cannot read properties of null (reading 'style')```

따라서 Code View 플러그인이 없을 경우에도 Full Screen 플러그인 기능이 작동하도록 수정하였습니다.