### PR TITLE
fix: Firefox iframe mode — empty content and non-functional buttons

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -13,3 +13,4 @@
 ### Bugfix
 
 - Fixed a bug where switching folders in the file browser did not update the item list and tags, causing search and tag filters to operate on stale data
+- Fixed iframe mode not working in Firefox — content was empty and buttons non-functional due to Firefox firing double `load` events for sandboxed iframes (`editor.js`, `constructor.js`)

--- a/src/core/editor.js
+++ b/src/core/editor.js
@@ -267,10 +267,25 @@ class Editor {
 
 			if (e.get('options').get('iframe')) {
 				const iframeLoaded = new Promise((resolve) => {
-					this.$.eventManager.addEvent(e.get('wysiwygFrame'), 'load', ({ target }) => {
-						this.#setIframeDocument(/** @type{HTMLIFrameElement} */ (target), this.$.optionProvider.options, e.get('options'));
+					const setupIframe = (/** @type{HTMLIFrameElement} */ target) => {
+						this.#setIframeDocument(target, this.$.optionProvider.options, e.get('options'));
 						resolve();
-					});
+					};
+
+					if (env.isGecko) {
+						// Firefox fires the iframe "load" event twice for sandboxed about:blank iframes —
+						// once for the initial document and again after sandbox processing replaces it.
+						// Debounce to ensure we initialize against the final document.
+						let debounceTimer = null;
+						this.$.eventManager.addEvent(e.get('wysiwygFrame'), 'load', ({ target }) => {
+							clearTimeout(debounceTimer);
+							debounceTimer = setTimeout(() => setupIframe(/** @type{HTMLIFrameElement} */ (target)), 60);
+						});
+					} else {
+						this.$.eventManager.addEvent(e.get('wysiwygFrame'), 'load', ({ target }) => {
+							setupIframe(/** @type{HTMLIFrameElement} */ (target));
+						});
+					}
 				});
 				iframePromises.push(iframeLoaded);
 			}

--- a/src/core/section/constructor.js
+++ b/src/core/section/constructor.js
@@ -946,7 +946,7 @@ function _initTargetElements(key, options, topDiv, targetOptions) {
 		// [sandbox] prop
 		let sandboxValue = frameAttrs.sandbox;
 		if (sandboxValue) {
-			const requiredSandbox = ['allow-same-origin'];
+			const requiredSandbox = ['allow-same-origin', 'allow-scripts'];
 			const userSandbox = sandboxValue.split(/\s+/);
 			const missingSandbox = requiredSandbox.filter((req) => !userSandbox.includes(req));
 
@@ -955,7 +955,7 @@ function _initTargetElements(key, options, topDiv, targetOptions) {
 				sandboxValue = userSandbox.concat(missingSandbox).join(' ');
 			}
 		} else {
-			sandboxValue = 'allow-same-origin';
+			sandboxValue = 'allow-same-origin allow-scripts';
 		}
 
 		// iframe [sandbox] attr


### PR DESCRIPTION
Firefox fires the iframe "load" event twice for sandboxed about:blank iframes (initial document + sandbox reprocessing), causing the editor to initialize against a stale document that gets replaced.

- Debounce iframe load handler on Firefox (env.isGecko) so the editor initializes against the final document after all load events settle
- Add "allow-scripts" to required sandbox values — Firefox requires it for contenteditable operations and execCommand