### PR TITLE
fix: layout and template dropdown plugins not responding to clicks

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -13,3 +13,4 @@
 ### Bugfix
 
 - Fixed a bug where switching folders in the file browser did not update the item list and tags, causing search and tag filters to operate on stale data
+- Fixed `layout` and `template` dropdown plugins not responding to clicks or keyboard selection due to missing `data-command` attribute on menu buttons

--- a/src/plugins/dropdown/layout.js
+++ b/src/plugins/dropdown/layout.js
@@ -75,7 +75,7 @@ function CreateHTML(layoutList) {
 		t = layoutList[i];
 		list += /*html*/ `
 			<li>
-				<button type="button" class="se-btn se-btn-list" data-value="${i}" title="${t.name}" aria-label="${t.name}">
+				<button type="button" class="se-btn se-btn-list" data-command="layout" data-value="${i}" title="${t.name}" aria-label="${t.name}">
 					${t.name}
 				</button>
 			</li>`;

--- a/src/plugins/dropdown/template.js
+++ b/src/plugins/dropdown/template.js
@@ -74,7 +74,8 @@ function CreateHTML(templateList) {
 		<li>
 			<button 
 				type="button" 
-				class="se-btn se-btn-list" 
+				class="se-btn se-btn-list"
+				data-command="template"
 				data-value="${i}" 
 				title="${t.name}" 
 				aria-label="${t.name}"


### PR DESCRIPTION
Both plugins were missing the `data-command` attribute on their menu buttons. The click dispatch chain (OnClick_menuTray → getCommandTarget) requires this attribute to identify actionable elements. Keyboard navigation (arrow keys, Enter) also depends on `[data-command]` selector in menu.js. Added the attribute to match the pattern used by the working hr plugin.