### PR TITLE
Fixed multiple issues when editing images with links in inline/block …

### DIFF
--- a/src/modules/contract/Figure.js
+++ b/src/modules/contract/Figure.js
@@ -282,7 +282,15 @@ class Figure {
 		const cover = dom.query.getParentElement(element, 'FIGURE', 2);
 		const inlineCover = dom.query.getParentElement(element, 'SPAN', 2);
 		const anyCover = cover || inlineCover;
-		const target = dom.query.getParentElement(element, (current) => current.parentElement === anyCover, 0) || /** @type {HTMLElement} */ (element);
+		let target = dom.query.getParentElement(element, (current) => current.parentElement === anyCover, 0) || /** @type {HTMLElement} */ (element);
+
+		// When image is wrapped by anchor, target becomes <a> instead of <img>
+		if (dom.check.isAnchor(target)) {
+			const imgEl = target.querySelector('img');
+			if (imgEl) {
+				target = imgEl;
+			}
+		}
 
 		return {
 			target,
@@ -734,11 +742,22 @@ class Figure {
 		const { container, inlineCover, target } = Figure.GetContainer(targetNode);
 		const { w, h } = this.getSize(target);
 
+		// Check if target is wrapped by an anchor
+		const anchorEl = dom.check.isAnchor(target.parentNode) ? target.parentNode : null;
+
 		const newTarget = /** @type {HTMLElement} */ (target.cloneNode(false));
 		newTarget.style.width = '';
 		newTarget.style.height = '';
 		newTarget.removeAttribute('width');
 		newTarget.removeAttribute('height');
+
+		// Preserve anchor wrapper if exists
+		let elementToInsert = newTarget;
+		if (anchorEl) {
+			const newAnchor = /** @type {HTMLElement} */ (anchorEl.cloneNode(false));
+			newAnchor.appendChild(newTarget);
+			elementToInsert = newAnchor;
+		}
 
 		switch (formatStyle) {
 			case 'inline': {
@@ -748,7 +767,7 @@ class Figure {
 				const next = container.nextElementSibling;
 				const parent = container.parentElement;
 
-				const figure = Figure.CreateInlineContainer(newTarget);
+				const figure = Figure.CreateInlineContainer(elementToInsert);
 				dom.utils.addClass(
 					figure.container,
 					container.className
@@ -777,7 +796,7 @@ class Figure {
 					dom.utils.removeItem(s.previousElementSibling);
 				}
 
-				const figure = Figure.CreateContainer(newTarget);
+				const figure = Figure.CreateContainer(elementToInsert);
 				dom.utils.addClass(
 					figure.container,
 					container.className


### PR DESCRIPTION
- **image**: Fixed multiple issues when editing images with links in inline/block format:

  - Fixed issue where Image URL and Alternative Text displayed "undefined" when editing an image wrapped by a link (`<a>` tag)
  - Fixed `insertBefore` error when editing inline images with links
  - Fixed link loss when editing inline images
  - Fixed link loss when changing Block Style from block to inline for images with links