### PR TITLE
fix: annotate generated form fields

### DIFF
--- a/src/core/section/constructor.js
+++ b/src/core/section/constructor.js
@@ -6,6 +6,7 @@ import { dom, numbers, converter, env } from '../../helper';
 import { DEFAULTS } from '../schema/options';
 
 const _d = env._d;
+let editorInstanceId = 0;
 
 /**
  * @typedef {import('../schema/options').AllBaseOptions} AllBaseOptions_constructor
@@ -57,6 +58,7 @@ function Constructor(editorTargets, options) {
 	const icons = optionMap.i;
 	const lang = optionMap.l;
 	const loadingBox = dom.utils.createElement('DIV', { class: 'se-loading-box sun-editor-common' }, '<div class="se-loading-effect"></div>');
+	const editorFormFieldPrefix = 'suneditor-' + ++editorInstanceId;
 
 	/** --- carrier wrapper --------------------------------------------------------------- */
 	const editor_carrier_wrapper = dom.utils.createElement('DIV', { class: 'sun-editor sun-editor-carrier-wrapper sun-editor-common' + o.get('_themeClass') + (o.get('_rtl') ? ' se-rtl' : '') });
@@ -66,7 +68,11 @@ function Constructor(editorTargets, options) {
 	// focus temp element
 	const focusTemp = /** @type {HTMLInputElement} */ (
 		dom.utils.createElement('INPUT', {
+			type: 'text',
+			id: editorFormFieldPrefix + '-focus-temp',
 			class: '__se__focus__temp__',
+			autocomplete: 'off',
+			'aria-hidden': 'true',
 			style: 'position: fixed !important; top: -10000px !important; left: -10000px !important; display: block !important; width: 0 !important; height: 0 !important; margin: 0 !important; padding: 0 !important;',
 		})
 	);
@@ -146,7 +152,7 @@ function Constructor(editorTargets, options) {
 		container.appendChild(dom.utils.createElement('DIV', { class: 'se-toolbar-shadow' }));
 
 		// init element
-		const initElements = _initTargetElements(editTarget.key, o, top_div, to);
+		const initElements = _initTargetElements(editTarget.key, o, top_div, to, editorFormFieldPrefix);
 		const bottomBar = initElements.bottomBar;
 		const statusbar = bottomBar.statusbar;
 		const wysiwyg_div = initElements.wysiwygFrame;
@@ -195,7 +201,11 @@ function Constructor(editorTargets, options) {
 			// not used code mirror
 			if (textarea === codeMirrorEl) {
 				// add line nubers
-				const codeNumbers = dom.utils.createElement('TEXTAREA', { class: 'se-code-view-line', readonly: 'true' }, null);
+				const codeNumbers = dom.utils.createElement(
+					'TEXTAREA',
+					{ id: editorFormFieldPrefix + '-code-view-line-' + (key || 'default'), class: 'se-code-view-line', readonly: 'true', autocomplete: 'off', 'aria-hidden': 'true', tabindex: '-1' },
+					null,
+				);
 				codeWrapper.insertBefore(codeNumbers, textarea);
 			} else {
 				textarea = codeMirrorEl;
@@ -207,7 +217,11 @@ function Constructor(editorTargets, options) {
 		let markdownTextarea = null;
 		if (o.get('buttons').has('markdownView')) {
 			markdownTextarea = initElements.markdownView;
-			const markdownNumbers = dom.utils.createElement('TEXTAREA', { class: 'se-markdown-view-line', readonly: 'true' }, null);
+			const markdownNumbers = dom.utils.createElement(
+				'TEXTAREA',
+				{ id: editorFormFieldPrefix + '-markdown-view-line-' + (key || 'default'), class: 'se-markdown-view-line', readonly: 'true', autocomplete: 'off', 'aria-hidden': 'true', tabindex: '-1' },
+				null,
+			);
 			markdownWrapper = dom.utils.createElement('DIV', { class: 'se-markdown-wrapper' });
 			markdownWrapper.appendChild(markdownNumbers);
 			markdownWrapper.appendChild(markdownTextarea);
@@ -934,9 +948,10 @@ function InitFrameOptions(o, origin) {
  * @param {Map<string, *>} options - Options
  * @param {HTMLElement} topDiv - Top div
  * @param {SunEditor.FrameOptions} targetOptions - `editor.frameOptions`
+ * @param {string} formFieldPrefix - Prefix for generated form field ids
  * @returns {{bottomBar: ReturnType<CreateStatusbar>, wysiwygFrame: HTMLElement, codeView: HTMLElement, markdownView: HTMLElement, placeholder: HTMLElement}}
  */
-function _initTargetElements(key, options, topDiv, targetOptions) {
+function _initTargetElements(key, options, topDiv, targetOptions, formFieldPrefix) {
 	const editorStyles = targetOptions.get('_defaultStyles');
 	/** top div */
 	topDiv.style.cssText = editorStyles.top;
@@ -990,10 +1005,10 @@ function _initTargetElements(key, options, topDiv, targetOptions) {
 	}
 
 	// textarea for code view
-	const textarea = dom.utils.createElement('TEXTAREA', { class: 'se-wrapper-inner se-code-viewer', style: editorStyles.frame });
+	const textarea = dom.utils.createElement('TEXTAREA', { id: formFieldPrefix + '-code-viewer-' + (key || 'default'), class: 'se-wrapper-inner se-code-viewer', style: editorStyles.frame, autocomplete: 'off' });
 
 	// textarea for markdown view
-	const markdownTextarea = dom.utils.createElement('TEXTAREA', { class: 'se-wrapper-inner se-markdown-viewer', style: editorStyles.frame });
+	const markdownTextarea = dom.utils.createElement('TEXTAREA', { id: formFieldPrefix + '-markdown-viewer-' + (key || 'default'), class: 'se-wrapper-inner se-markdown-viewer', style: editorStyles.frame, autocomplete: 'off' });
 
 	const placeholder = dom.utils.createElement('SPAN', { class: 'se-placeholder' });
 	if (targetOptions.get('placeholder')) {

--- a/test/unit/core/section/constructor.spec.js
+++ b/test/unit/core/section/constructor.spec.js
@@ -11,6 +11,10 @@ import Constructor, {
 } from '../../../../src/core/section/constructor';
 
 describe('Core Section - Constructor', () => {
+    afterEach(() => {
+        document.querySelectorAll('.sun-editor-carrier-wrapper, .sun-editor').forEach((element) => element.remove());
+    });
+
     describe('Exported functions', () => {
         it('should export Constructor as default function', () => {
             expect(typeof Constructor).toBe('function');
@@ -34,6 +38,32 @@ describe('Core Section - Constructor', () => {
 
         it('should export CreateToolBar as function', () => {
             expect(typeof CreateToolBar).toBe('function');
+        });
+    });
+
+    describe('Constructor DOM', () => {
+        it('should annotate generated form fields to avoid browser form warnings', () => {
+            const target = document.createElement('textarea');
+
+            const result = Constructor([{ target, key: null, options: {} }], {
+                buttonList: [['codeView', 'markdownView']]
+            });
+
+            const focusTemp = result.carrierWrapper.querySelector('.__se__focus__temp__');
+            const frame = result.frameRoots.get(null);
+            const codeWrapper = frame.get('codeWrapper');
+            const markdownWrapper = frame.get('markdownWrapper');
+            const codeView = frame.get('code');
+            const markdownView = frame.get('markdown');
+
+            expect(focusTemp.id).toMatch(/^suneditor-\d+-focus-temp$/);
+            expect(focusTemp.getAttribute('autocomplete')).toBe('off');
+            expect(focusTemp.getAttribute('aria-hidden')).toBe('true');
+
+            [codeView, markdownView, codeWrapper.querySelector('.se-code-view-line'), markdownWrapper.querySelector('.se-markdown-view-line')].forEach((field) => {
+                expect(field.id).toMatch(/^suneditor-\d+-/);
+                expect(field.getAttribute('autocomplete')).toBe('off');
+            });
         });
     });
 


### PR DESCRIPTION
## Summary
- add stable ids and autocomplete=off to SunEditor-generated internal input/textarea fields
- mark decorative line-number textareas as aria-hidden and remove them from tab order
- add a unit test covering the generated field attributes

## Why
Chrome surfaces form warnings when generated editor controls have neither id nor name, or recognized fields miss autocomplete. The added ids avoid changing form submission payloads while silencing those diagnostics.

## Test
- npm test -- --runTestsByPath test/unit/core/section/constructor.spec.js
- npm run lint:type
- npx eslint src/core/section/constructor.js